### PR TITLE
ci: run unit + e2e smoke tests on PRs to docker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - docker
+  push:
+    branches:
+      - docker
+
+jobs:
+  unit-and-e2e:
+    name: Unit + E2E Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run unit + e2e smoke tests
+        run: ./scripts/run-tests.sh --with-e2e


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that runs ./scripts/run-tests.sh --with-e2e on pull requests and pushes for the docker branch.