### PR TITLE
docs: refactor README with feature overview and install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,73 @@
-FoOlSlide Improved
-=========
+# FoOlSlide Improved
 
-__THIS IS AN UNOFFICIAL PROJECT__
+This is an unofficial continuation of the FoOlSlide reader, focused on maintainability, modern PHP compatibility, and a better admin + reading experience.
 
-FoOlSlide is a ridiculously elaborated comic reader meant for users to enjoy reading.</br> 
-This is a significant improvement of the original FoOlSlide reader project. This updated version let you organize your comics into categories and tags. There are many new tools and views you can use to make a better exploration of your content.<br />
-Note that this project improved the frontend as well, providing a mobile-friendly version of the reader. The admin panel theme was maninly inspired by the work of [chocolatkey's FoOlSlide2](https://github.com/chocolatkey/FoOlSlide2).
+## Main Features
+- Reader and admin panel tailored for manga/doujin archives.
+- Comic organization with series metadata, categories, tags, teams, and releases.
+- Mobile-friendly frontend theme and improved browsing/navigation flows.
+- Migration-based schema updates to keep instances consistent over time.
+- Docker-first local development flow for fast setup and reproducible environments.
 
+## Tech Overview
+- Framework: CodeIgniter-based legacy application (FoOlSlide stack).
+- Runtime data under `content/` (comics, tags, cache, logs).
+- Docker services:
+  - `web` (PHP + Apache)
+  - `db` (MySQL)
 
-Installation
-------------
-1.  Copy everything in the archive in a public server folder
-2.  Create a database (MySQL, MSSQL, MySQLi, SQLite...)
-3.  Go to http://yourdomain.com/slidefolder/install
-4.  Insert database info and admin account info
-5.  Done
+## Standard Installation (Server)
+1. Copy project files into your web-accessible directory.
+2. Ensure writable directories exist and are writable by the web user:
+   - `content/cache`
+   - `content/comics`
+   - `content/tags`
+   - `content/logs`
+3. Create a MySQL database and user.
+4. Open `/install` in your browser (for example: `https://your-domain/install`).
+5. Complete the installer with DB credentials and admin user details.
+6. Sign in to the admin area and configure site options.
 
-Unit tests
-----------
-- Controller unit tests are in `tests/controllers/` and follow the `*Test.php` suffix.
-- Test bootstrap and lightweight CodeIgniter stubs are in `tests/bootstrap.php`.
-- Run tests with `./scripts/run-tests.sh`.
-- Run tests + Docker Compose E2E smoke checks with `./scripts/run-tests.sh --with-e2e`.
-- The script falls back in this order: host `phpunit`, `vendor/bin/phpunit`, Docker (`docker compose run --rm web ...`).
+## Run Locally with Docker Compose
+To run the full stack locally:
+
+```bash
+docker compose up --build
+```
+
+Then open:
+- `http://localhost:8080/`
+- `http://localhost:8080/install` (first-time setup)
+
+Useful lifecycle commands:
+
+```bash
+docker compose down
+docker compose ps
+docker compose logs -f web
+```
+
+Notes:
+- Named volumes are used for persistent data (`db_data`, `content_*`), so data survives normal `docker compose down`.
+- Containers can be rebuilt without losing DB/comics data unless volumes are explicitly removed.
+
+## Testing
+- Unit tests are under `tests/controllers/` (`*Test.php`).
+- Test bootstrap is in `tests/bootstrap.php`.
+
+Run unit tests:
+
+```bash
+./scripts/run-tests.sh
+```
+
+Run unit tests + Docker Compose E2E smoke checks:
+
+```bash
+./scripts/run-tests.sh --with-e2e
+```
+
+The test runner tries, in order:
+1. host `phpunit`
+2. `vendor/bin/phpunit`
+3. Docker (`docker compose run --rm web ...`)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is an unofficial continuation of the FoOlSlide reader, focused on maintainability, modern PHP compatibility, and a better admin + reading experience.
 
-Note that this project improved the frontend as well, providing a mobile-friendly version of the reader. The admin panel theme was maninly inspired by the work of chocolatkey's FoOlSlide2.
+Note that this project improved the frontend as well, providing a mobile-friendly version of the reader. The admin panel theme was maninly inspired by the work of [chocolatkey's FoOlSlide2](https://github.com/chocolatkey/FoOlSlide2).
 
 ## Main Features
 - Reader and admin panel tailored for manga/doujin archives.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is an unofficial continuation of the FoOlSlide reader, focused on maintainability, modern PHP compatibility, and a better admin + reading experience.
 
+Note that this project improved the frontend as well, providing a mobile-friendly version of the reader. The admin panel theme was maninly inspired by the work of chocolatkey's FoOlSlide2.
+
 ## Main Features
 - Reader and admin panel tailored for manga/doujin archives.
 - Comic organization with series metadata, categories, tags, teams, and releases.


### PR DESCRIPTION
## Summary
- Heavily refactors README structure and content for clarity.
- Documents main FoOlSlide Improved features and architecture.
- Adds a clearer standard installation flow.
- Adds a dedicated section for running locally with Docker Compose.
- Keeps testing instructions explicit, including [tests] Host php is unavailable, skipping vendor/bin/phpunit and falling back to Docker
[tests] Running phpunit in Docker (service: web)
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: phpunit.xml

.................                                                 17 / 17 (100%)

Time: 00:00.005, Memory: 6.00 MB

OK (17 tests, 30 assertions)
[tests] Running e2e smoke suite
[e2e] Starting Docker Compose stack
#1 [internal] load local bake definitions
#1 reading from stdin 554B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 886B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/php:8.4-apache
#3 DONE 0.6s

#4 [internal] load .dockerignore
#4 transferring context: 2B done
#4 DONE 0.0s

#5 [ 1/15] FROM docker.io/library/php:8.4-apache@sha256:ddb5905729cec1a5e85556f631c578bff8f3f7fa03b0726fe594474df20199f0
#5 DONE 0.0s

#6 [internal] load build context
#6 transferring context: 376.11kB 0.1s done
#6 DONE 0.1s

#7 [ 4/15] RUN echo "date.timezone = UTC" > /usr/local/etc/php/conf.d/timezone.ini
#7 CACHED

#8 [ 6/15] COPY apache-vhost.conf /etc/apache2/sites-available/000-default.conf
#8 CACHED

#9 [ 2/15] RUN apt-get update && apt-get install -y --no-install-recommends     libfreetype6-dev     libjpeg62-turbo-dev     libpng-dev     libzip-dev     libxml2-dev     && rm -rf /var/lib/apt/lists/*
#9 CACHED

#10 [ 5/15] RUN a2enmod rewrite
#10 CACHED

#11 [ 3/15] RUN docker-php-ext-configure gd --with-freetype --with-jpeg     && docker-php-ext-install -j$(nproc) gd mysqli zip xml
#11 CACHED

#12 [ 7/15] WORKDIR /var/www/html
#12 CACHED

#13 [ 8/15] COPY . /var/www/html/
#13 DONE 0.3s

#14 [ 9/15] COPY .htaccess /var/www/html/.htaccess
#14 DONE 0.0s

#15 [10/15] RUN mkdir -p /var/www/html/content/logs
#15 DONE 0.1s

#16 [11/15] RUN mkdir -p /var/www/html/content/cache
#16 DONE 0.1s

#17 [12/15] RUN mkdir -p /var/www/html/content/comics
#17 DONE 0.2s

#18 [13/15] RUN mkdir -p /var/www/html/content/tags
#18 DONE 0.2s

#19 [14/15] RUN chown -R www-data:www-data /var/www/html
#19 DONE 0.2s

#20 [15/15] RUN chmod -R 777 /var/www/html
#20 DONE 0.3s

#21 exporting to image
#21 exporting layers
#21 exporting layers 0.8s done
#21 writing image sha256:d45ce601114d87ae3fc4724e6e0bb6597d2817933adf05e70d7332cd944bf722 done
#21 naming to docker.io/library/foolslide-improved-web done
#21 DONE 0.8s

#22 resolving provenance for metadata file
#22 DONE 0.0s
[e2e] Waiting for http://localhost:8080 to become reachable
[e2e] / -> status=200 bytes=25835
[e2e] /latest/ -> status=200 bytes=25835
[e2e] /account/auth/login/ -> status=200 bytes=5370
[e2e] /admin/ -> status=200 bytes=5370
[e2e] /install -> status=200 bytes=5370
[e2e] PASS: smoke routes are serving HTML pages correctly..

## Verification
- [tests] Host php is unavailable, skipping vendor/bin/phpunit and falling back to Docker
[tests] Running phpunit in Docker (service: web)
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: phpunit.xml

.................                                                 17 / 17 (100%)

Time: 00:00.002, Memory: 6.00 MB

OK (17 tests, 30 assertions)