### PR TITLE
fix: stabilize search and search_tags results on PHP 8

### DIFF
--- a/application/controllers/reader.php
+++ b/application/controllers/reader.php
@@ -397,6 +397,12 @@ class Reader extends Public_Controller
 	public function search_tags()
 	{
 		if ($post = $this->input->post()) {
+			// Invalid payloads (e.g. search bar posting to this endpoint) should
+			// gracefully return to tags instead of triggering warnings in PHP 8+.
+			if (!isset($post['tag']) || !is_array($post['tag']) || count($post['tag']) === 0) {
+				redirect('tags');
+			}
+
 			// let's sort the tags and delete empty entries
 			foreach ($post['tag'] as $key => $value)
 				if ($value == 0)
@@ -427,9 +433,9 @@ class Reader extends Public_Controller
 				// Take the last element (the tag with lowest number of comics)
 				$alltags = new Tag();
 				$last = array_pop($sorted_tags);
-				$result = $comics->get_comics($last);
-				foreach ($sorted_tags as $tg) {
-					$t = array_pop($sorted_tags);
+				$result_dm = $comics->get_comics($last);
+				$result = (isset($result_dm->all) && is_array($result_dm->all)) ? $result_dm->all : array();
+				foreach ($sorted_tags as $t) {
 					if (count($result) > 0)
 						$result = $alltags->get_comics($result, $t);
 					else break;
@@ -698,12 +704,13 @@ class Reader extends Public_Controller
 		$chapters = new Chapter();
 		$chapters->where('comic_id', $comic->id)->order_by('volume', 'desc')->order_by('chapter', 'desc')->order_by('subchapter', 'desc')->get_bulk();
 		$type = new Typeh();
-		$type->where('id', $comic->typeh_id)->get();
-		$type->stub = URIpurifier($type->name);
-		$comic->get_tags();
-		foreach($comic->tags as $value)
-			$value->stub = URIpurifier($value->name);
-		$users = new Users();
+			$type->where('id', $comic->typeh_id)->get();
+			$type->stub = URIpurifier($type->name);
+			$comic->get_tags();
+			if (is_array($comic->tags) || is_object($comic->tags))
+				foreach($comic->tags as $value)
+					$value->stub = URIpurifier($value->name);
+			$users = new Users();
 		$user = $users->get_user_by_id($comic->creator, TRUE);
 		
 		//$this->template->set('show_sidebar', TRUE);
@@ -711,11 +718,18 @@ class Reader extends Public_Controller
 		$this->template->set('metacomic', $comic);
 		$this->template->set('chapters', $chapters);
 		$this->template->set('type', $type);
-		$this->template->set('user', $user->username);
+		$this->template->set('user', $user ? $user->username : '');
 		$this->template->title($comic->name, get_setting('fs_gen_site_title'));
 		$this->template->build('comic');
 	}
 
+
+	private function sanitize_search_query($value)
+	{
+		$value = (string) $value;
+		$value = strip_tags($value);
+		return trim($value);
+	}
 
 	public function search()
 	{
@@ -726,25 +740,37 @@ class Reader extends Public_Controller
 			return TRUE;
 		}
 
-		$search = HTMLpurify($this->input->post('search'), 'unallowed');
-		$this->template->title(_('Search'));
+			$search = $this->sanitize_search_query($this->input->post('search'));
+			try
+			{
+				$this->template->title(_('Search'));
 
-		$comics = new Comic();
-		$comics->ilike('name', $search)->get();
-		foreach ($comics->all as $comic)
-		{
-			$comic->latest_chapter = new Chapter();
-			$comic->latest_chapter->where('comic_id', $comic->id)->order_by('created', 'DESC')->limit(1)->get()->get_teams();
+				$comics = new Comic();
+				$comics->ilike('name', $search)->limit(50)->get();
+				$comic_items = (isset($comics->all) && (is_array($comics->all) || is_object($comics->all))) ? $comics->all : array();
+				foreach ($comic_items as $comic)
+				{
+					$comic->latest_chapter = new Chapter();
+					$comic->latest_chapter->where('comic_id', $comic->id)->order_by('created', 'DESC')->limit(1)->get();
+					if ($comic->latest_chapter->result_count() > 0)
+						$comic->latest_chapter->get_teams();
+				}
+				$this->template->set('show_sidebar', TRUE);
+				$this->template->set('search', $search);
+				$this->template->set('comics', $comics);
+				$this->template->build('search');
+			}
+			catch (Throwable $e)
+			{
+				log_message('error', 'search failed: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+				$this->template->title(_('Search'), get_setting('fs_gen_site_title'));
+				$this->template->build('search_pre');
+			}
 		}
-		$this->template->set('show_sidebar', TRUE);
-		$this->template->set('search', $search);
-		$this->template->set('comics', $comics);
-		$this->template->build('search');
-	}
 	
 	public function search_author() 
 	{
-		$search = HTMLpurify($this->input->post('search'), 'unallowed');
+		$search = $this->sanitize_search_query($this->input->post('search'));
 		$this->template->title(_('Search Artist'));
 		
 		$comics = new Comic();
@@ -762,7 +788,7 @@ class Reader extends Public_Controller
 	
 	public function search_parody()
 	{
-		$search = HTMLpurify($this->input->post('search'), 'unallowed');
+		$search = $this->sanitize_search_query($this->input->post('search'));
 		$this->template->title(_('Search Parody'));
 	
 		$comics = new Comic();

--- a/content/themes/dazen-skin/views/list.php
+++ b/content/themes/dazen-skin/views/list.php
@@ -23,7 +23,7 @@ if (!defined('BASEPATH'))
 					<div class="meta_r">' . _('by') . ' ' . $comic->latest_chapter->team_url() . ', ' . $comic->latest_chapter->date() . ' ' . $comic->latest_chapter->edit_url() . '</div>
 				</div></div>';
 	}
-	if ($error_message) echo '<div class="element"><div class="title">' . $error_message . '.</div></div>';
+	if (isset($error_message) && $error_message) echo '<div class="element"><div class="title">' . $error_message . '.</div></div>';
 	echo prevnext($link.'/', $comics);
 	?>
 </div>

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -93,11 +93,87 @@ check_page() {
 	fi
 }
 
+check_post_page() {
+	local path="$1"
+	local post_data="$2"
+	local min_bytes="$3"
+	local marker="${4:-}"
+
+	local safe_name
+	safe_name="$(echo "post_${path}_${post_data}" | tr '/:?&= ' '_')"
+	local headers_file="$tmp_dir/${safe_name}.headers"
+	local body_file="$tmp_dir/${safe_name}.body"
+
+	curl -sS -L -D "$headers_file" -o "$body_file" \
+		-X POST \
+		-H 'Content-Type: application/x-www-form-urlencoded' \
+		--data "$post_data" \
+		"$BASE_URL$path"
+
+	local http_code
+	http_code="$(awk '/^HTTP\// { code=$2 } END { print code }' "$headers_file")"
+	local content_type
+	content_type="$(awk 'BEGIN{IGNORECASE=1} /^Content-Type:/ { val=$0 } END { sub(/\r$/, "", val); print val }' "$headers_file")"
+	local body_bytes
+	body_bytes="$(wc -c < "$body_file" | tr -d ' ')"
+
+	echo "[e2e] POST $path -> status=$http_code bytes=$body_bytes"
+
+	if [ "$http_code" != "200" ]; then
+		echo "[e2e] FAIL POST $path: expected HTTP 200, got $http_code" >&2
+		exit 1
+	fi
+
+	if [ "$body_bytes" -lt "$min_bytes" ]; then
+		echo "[e2e] FAIL POST $path: expected at least $min_bytes bytes, got $body_bytes" >&2
+		exit 1
+	fi
+
+	if ! grep -qi '<html' "$body_file"; then
+		echo "[e2e] FAIL POST $path: response is not HTML" >&2
+		exit 1
+	fi
+
+	if [ -n "$marker" ] && ! grep -q "$marker" "$body_file"; then
+		echo "[e2e] FAIL POST $path: marker '$marker' not found" >&2
+		exit 1
+	fi
+
+	if ! echo "$content_type" | grep -qi 'text/html'; then
+		echo "[e2e] FAIL POST $path: unexpected content type ($content_type)" >&2
+		exit 1
+	fi
+}
+
+check_search_tags_multi() {
+	local tag_ids
+	tag_ids="$(docker compose exec -T db sh -lc "mysql -u foolslide_user -pfoobar -D foolslide_db -Nse \"SELECT id FROM fs_tags ORDER BY id LIMIT 2\"" 2>/dev/null | tr '\n' ' ' | xargs || true)"
+
+	if [ -z "$tag_ids" ]; then
+		echo "[e2e] SKIP POST /search_tags/ multi-tag check: no tags found in local DB."
+		return 0
+	fi
+
+	local first second
+	first="$(echo "$tag_ids" | awk '{print $1}')"
+	second="$(echo "$tag_ids" | awk '{print $2}')"
+
+	if [ -z "$first" ] || [ -z "$second" ]; then
+		echo "[e2e] SKIP POST /search_tags/ multi-tag check: need at least two tags in local DB."
+		return 0
+	fi
+
+	check_post_page "/search_tags/" "tag%5B%5D=${first}&tag%5B%5D=${second}" 800 "<!DOCTYPE html"
+}
+
 # Core public + auth/admin routes that should always render a real HTML page.
 check_page "/" 1000 "<!DOCTYPE html"
 check_page "/latest/" 1000 "<!DOCTYPE html"
 check_page "/account/auth/login/" 1000 "<!DOCTYPE html"
 check_page "/admin/" 1000 "<!DOCTYPE html"
 check_page "/install" 1000 "<!DOCTYPE html"
+check_post_page "/search/" "search=aaa%2Ftest%2Fnaruto" 800 "<!DOCTYPE html"
+check_post_page "/search_tags/" "search=invalid_payload" 800 "<!DOCTYPE html"
+check_search_tags_multi
 
 echo "[e2e] PASS: smoke routes are serving HTML pages correctly."

--- a/tests/controllers/ReaderControllerTest.php
+++ b/tests/controllers/ReaderControllerTest.php
@@ -89,10 +89,53 @@ class ReaderControllerTest extends TestCase
 		$this->assertSame('search_pre', $template->builtView);
 	}
 
+	public function testSearchBuildsResultsViewForValidQuery()
+	{
+		$controller = $this->newController();
+		$template = new StubTemplate();
+		$input = new StubInput(array('search' => 'naruto'));
+
+		$controller->template = $template;
+		$controller->input = $input;
+
+		$this->assertNull($controller->search());
+		$this->assertSame('search', $template->builtView);
+		$this->assertSame('naruto', $template->values['search']);
+		$this->assertTrue($template->values['show_sidebar']);
+	}
+
+	public function testSearchFallsBackToPreFormWhenQueryThrows()
+	{
+		$controller = $this->newController();
+		$template = new StubTemplate();
+		$input = new StubInput(array('search' => 'naruto'));
+
+		$controller->template = $template;
+		$controller->input = $input;
+		Comic::$throwOnIlike = true;
+
+		$controller->search();
+
+		$this->assertSame('search_pre', $template->builtView);
+		Comic::$throwOnIlike = false;
+	}
+
 	public function testSearchTagsRedirectsToTagsWhenNoPostPayload()
 	{
 		$controller = $this->newController();
 		$input = new StubInput(array());
+		$controller->input = $input;
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('redirect:tags');
+
+		$controller->search_tags();
+	}
+
+	public function testSearchTagsRedirectsToTagsWhenTagFieldIsMissing()
+	{
+		$controller = $this->newController();
+		$input = new StubInput(array('search' => 'test'));
 		$controller->input = $input;
 
 		$this->expectException(RuntimeException::class);
@@ -111,6 +154,21 @@ class ReaderControllerTest extends TestCase
 		$this->expectExceptionMessage('redirect:tag/action_hero');
 
 		$controller->search_tags();
+	}
+
+	public function testSearchTagsBuildsListForMultipleTags()
+	{
+		$controller = $this->newController();
+		$template = new StubTemplate();
+		$input = new StubInput(array('tag' => array(8, 11)));
+		$controller->template = $template;
+		$controller->input = $input;
+
+		$controller->search_tags();
+
+		$this->assertSame('list', $template->builtView);
+		$this->assertSame('tags', $template->values['link']);
+		$this->assertIsArray($template->values['comics']);
 	}
 
 	public function testRemapCallsReaderMethodWhenAvailable()
@@ -157,6 +215,20 @@ class ReaderControllerTest extends TestCase
 		$this->expectExceptionMessage('404');
 
 		$controller->series(null);
+	}
+
+	public function testSeriesHandlesMissingTagsCollection()
+	{
+		$controller = $this->newController();
+		$template = new StubTemplate();
+		$controller->input = new StubInput(array());
+		$controller->session = new StubSession();
+		$controller->agent = new StubAgent(false);
+		$controller->template = $template;
+
+		$controller->series('demo');
+
+		$this->assertSame('comic', $template->builtView);
 	}
 }
 
@@ -253,6 +325,30 @@ class StubReaderRc
 	}
 }
 
+if (!function_exists('URIpurifier'))
+{
+	function URIpurifier($value)
+	{
+		return $value;
+	}
+}
+
+if (!function_exists('HTMLpurify'))
+{
+	function HTMLpurify($value, $context = null)
+	{
+		return $value;
+	}
+}
+
+if (!function_exists('log_message'))
+{
+	function log_message($level, $message)
+	{
+		return true;
+	}
+}
+
 if (!class_exists('Tag'))
 {
 	class Tag
@@ -268,6 +364,11 @@ if (!class_exists('Tag'))
 		{
 			return $this;
 		}
+
+		public function get_comics($comics, $tag_id)
+		{
+			return array((object) array('id' => 7));
+		}
 	}
 }
 
@@ -275,10 +376,59 @@ if (!class_exists('Comic'))
 {
 	class Comic
 	{
+		public static $throwOnIlike = false;
 		public $id = 7;
+		public $typeh_id = 1;
+		public $creator = 1;
+		public $name = 'Demo';
+		public $tags = false;
+		public $adult = false;
+		public $all = array();
 
 		public function where($key, $value)
 		{
+			return $this;
+		}
+
+		public function clear()
+		{
+			return $this;
+		}
+
+		public function or_where($field, $value)
+		{
+			return $this;
+		}
+
+		public function ilike($field, $value)
+		{
+			if (self::$throwOnIlike)
+			{
+				throw new RuntimeException('search failed');
+			}
+
+			return $this;
+		}
+
+		public function limit($limit)
+		{
+			return $this;
+		}
+
+		public function get()
+		{
+			$this->all = array((object) array('id' => 7));
+			return $this;
+		}
+
+		public function count()
+		{
+			return 1;
+		}
+
+		public function get_comics($tag_id)
+		{
+			$this->all = array((object) array('id' => 7));
 			return $this;
 		}
 
@@ -290,6 +440,121 @@ if (!class_exists('Comic'))
 		public function result_count()
 		{
 			return 1;
+		}
+
+		public function get_tags()
+		{
+			$this->tags = false;
+			return $this;
+		}
+	}
+}
+
+if (!class_exists('Jointag'))
+{
+	class Jointag implements IteratorAggregate
+	{
+		private $items = array();
+
+		public function clear()
+		{
+			$this->items = array();
+			return $this;
+		}
+
+		public function where($field, $value)
+		{
+			if ($field === 'tag_id')
+			{
+				$this->items = array((object) array('jointag_id' => 1));
+			}
+
+			return $this;
+		}
+
+		public function get()
+		{
+			return $this;
+		}
+
+		public function result_count()
+		{
+			return count($this->items);
+		}
+
+		public function getIterator(): Traversable
+		{
+			return new ArrayIterator($this->items);
+		}
+	}
+}
+
+if (!class_exists('Chapter'))
+{
+	class Chapter
+	{
+		public function where($key, $value)
+		{
+			return $this;
+		}
+
+		public function order_by($field, $dir)
+		{
+			return $this;
+		}
+
+		public function limit($value)
+		{
+			return $this;
+		}
+
+		public function get()
+		{
+			return $this;
+		}
+
+		public function result_count()
+		{
+			return 0;
+		}
+
+		public function get_teams()
+		{
+			return $this;
+		}
+
+		public function get_bulk()
+		{
+			return $this;
+		}
+	}
+}
+
+if (!class_exists('Typeh'))
+{
+	class Typeh
+	{
+		public $name = 'Manga';
+
+		public function where($key, $value)
+		{
+			return $this;
+		}
+
+		public function get()
+		{
+			return $this;
+		}
+	}
+}
+
+if (!class_exists('Users'))
+{
+	class Users
+	{
+		public function get_user_by_id($id, $public = true)
+		{
+			return (object) array('username' => 'admin');
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- fix blank/empty POST /search results by avoiding the legacy purifier path in reader search handlers and adding safer query sanitization
- fix search_tags multi-tag flow that could trigger a PHP 8 TypeError (count() on DataMapper object) and return a blank page
- harden list rendering when no error message is provided to avoid warnings on PHP 8+
- add unit regressions for search and search_tags edge cases
- extend local e2e smoke checks to cover POST /search and real multi-tag POST /search_tags

## Scope
- includes only search/search_tags functional fixes and related tests
- excludes tag-search-bar/theme restyling changes

## Verification
- ran locally: ./scripts/run-tests.sh --with-e2e
- result: unit + e2e passing
