### PR TITLE
fix: restore legacy phpass logins on PHP 8

### DIFF
--- a/application/libraries/phpass-0.1/PasswordHash.php
+++ b/application/libraries/phpass-0.1/PasswordHash.php
@@ -30,7 +30,18 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
+	function __construct($iteration_count_log2, $portable_hashes)
+	{
+		$this->init($iteration_count_log2, $portable_hashes);
+	}
+
+	// PHP 4-style constructor retained for backwards compatibility.
 	function PasswordHash($iteration_count_log2, $portable_hashes)
+	{
+		$this->init($iteration_count_log2, $portable_hashes);
+	}
+
+	private function init($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
## Summary
- fix PHP 8 compatibility in bundled phpass by adding a `__construct()` initializer in `PasswordHash`
- keep legacy constructor method for backward compatibility
- restores login verification for existing legacy `$P$...` password hashes (users created before bcrypt migration)

## Root Cause
- on PHP 8, old-style constructor `PasswordHash()` is not treated as constructor
- object properties remained uninitialized, so `CheckPassword()` failed for phpass hashes
- bcrypt users could still authenticate via `crypt()` fallback, making the issue appear user-specific

## Verification
- local runtime check in container confirmed `$P$` hash verification works again
- ran full suite: `./scripts/run-tests.sh --with-e2e` (pass)
