### PR TITLE
fix: dazen reader edge navigation and host-scoped auth cookies

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -248,7 +248,10 @@ $config['encryption_key'] = '';
   | 'sess_time_to_update'		= how many seconds between CI refreshing Session Information
   |
  */
-$config['sess_cookie_name'] = 'ci_session';
+$session_host = isset($_SERVER['HTTP_HOST']) ? strtolower($_SERVER['HTTP_HOST']) : 'cli';
+$session_host = preg_replace('/:\d+$/', '', $session_host);
+$session_host_hash = substr(md5($session_host), 0, 8);
+$config['sess_cookie_name'] = 'ci_session_' . $session_host_hash;
 $config['sess_expiration'] = 7200;
 $config['sess_expire_on_close'] = FALSE;
 $config['sess_encrypt_cookie'] = TRUE;
@@ -268,7 +271,7 @@ $config['sess_time_to_update'] = 300;
   | 'cookie_path'   =  Typically will be a forward slash
   |
  */
-$config['cookie_prefix'] = '';
+$config['cookie_prefix'] = 'fs_' . $session_host_hash . '_';
 $config['cookie_domain'] = '';
 $config['cookie_path'] = '/';
 

--- a/application/config/tank_auth.php
+++ b/application/config/tank_auth.php
@@ -84,7 +84,10 @@ $config['login_attempt_expire'] = 60*60*24;
 | 'autologin_cookie_life' = Auto login cookie life before expired. Default is 2 months (60*60*24*31*2).
 |--------------------------------------------------------------------------
 */
-$config['autologin_cookie_name'] = 'autologin';
+$autologin_host = isset($_SERVER['HTTP_HOST']) ? strtolower($_SERVER['HTTP_HOST']) : 'cli';
+$autologin_host = preg_replace('/:\d+$/', '', $autologin_host);
+$autologin_host_hash = substr(md5($autologin_host), 0, 8);
+$config['autologin_cookie_name'] = 'autologin_' . $autologin_host_hash;
 $config['autologin_cookie_life'] = 60*60*24*31*2;
 
 /*

--- a/content/themes/dazen-skin/views/read.php
+++ b/content/themes/dazen-skin/views/read.php
@@ -136,8 +136,11 @@ if (!defined('BASEPATH'))
   padding: 0; margin: 0;
   cursor: pointer;
   outline: none;
+  z-index: 20;
+  pointer-events: auto;
   -webkit-tap-highlight-color: transparent;
 }
+#page .inner img.open{ position: relative; z-index: 1; }
 #page .inner .nav-left  { left: 0; }
 #page .inner .nav-right { right: 0; }
 #page .inner .nav-zone:focus{ outline: none; }
@@ -408,11 +411,19 @@ if (!defined('BASEPATH'))
     var $img = $inner.find('a img.open').clone();
     $inner.empty().append($img);
 
-    $inner.append('<button class="nav-zone nav-left"  aria-label="Previous page"></button>'+
-                  '<button class="nav-zone nav-right" aria-label="Next page"></button>');
+    $inner.append('<button type="button" class="nav-zone nav-left" aria-label="Previous page"></button>'+
+                  '<button type="button" class="nav-zone nav-right" aria-label="Next page"></button>');
 
-    $inner.on('click', '.nav-left',  function(e){ e.preventDefault(); prevPage(); });
-    $inner.on('click', '.nav-right', function(e){ e.preventDefault(); nextPage(); });
+    $inner.find('.nav-left').bind('click', function(e){ e.preventDefault(); prevPage(); });
+    $inner.find('.nav-right').bind('click', function(e){ e.preventDefault(); nextPage(); });
+    // Desktop fallback: click left/right area even if overlay buttons are not hit.
+    $inner.bind('click', function(e){
+      if (jQuery(e.target).closest('.nav-zone').length) return;
+      var x = e.pageX - $inner.offset().left;
+      var w = $inner.width();
+      if (x < w * 0.4) prevPage();
+      else if (x > w * 0.6) nextPage();
+    });
 
     // Touch: drag solo se zoom; altrimenti swipe/tap area
     var touchState = { startXRel:0, startY:0, lastX:0, lastY:0, isDragging:false };
@@ -424,7 +435,7 @@ if (!defined('BASEPATH'))
       return matrix.a;
     }
 
-    $inner.on('touchstart', function(event){
+    $inner.bind('touchstart', function(event){
       if (event.originalEvent.touches.length === 1) {
         var imgEl = $inner.find('img.open')[0];
         var scale = getCurrentScale(imgEl);
@@ -447,7 +458,7 @@ if (!defined('BASEPATH'))
       }
     });
 
-    $inner.on('touchmove', function(event){
+    $inner.bind('touchmove', function(event){
       if (touchState.isDragging && event.originalEvent.touches.length === 1) {
         var touch = event.originalEvent.touches[0];
         var img = $inner.find('img.open');
@@ -464,7 +475,7 @@ if (!defined('BASEPATH'))
       }
     });
 
-    $inner.on('touchend', function(event){
+    $inner.bind('touchend', function(event){
       if (!touchState.isDragging) {
         var rect = this.getBoundingClientRect();
         var endXRel = event.changedTouches[0].clientX - rect.left;
@@ -486,7 +497,6 @@ if (!defined('BASEPATH'))
 </script>
 
 <script>
-<script>
 jQuery(function($){
   var $parents = $('.dropdown_parent');
 
@@ -497,8 +507,8 @@ jQuery(function($){
 
   // Handler click SOLO per mobile/tablet (niente hover affidabile)
   function bindMobileClick(){
-    $parents.off('.dd'); // pulizia eventuali handler precedenti
-    $parents.on('click.dd', '.text, .text_only', function(e){
+    $parents.undelegate('.text, .text_only', 'click.dd'); // pulizia eventuali handler precedenti
+    $parents.delegate('.text, .text_only', 'click.dd', function(e){
       var $p = $(this).closest('.dropdown_parent');
 
       // Se non c'è il dropdown, lascia navigare tranquillamente (link puro)
@@ -513,18 +523,18 @@ jQuery(function($){
     });
 
     // Chiudi cliccando fuori o con ESC
-    $(document).on('click.dd', function(e){
+    $(document).unbind('click.dd').bind('click.dd', function(e){
       if (!$(e.target).closest('.dropdown_parent').length) $parents.removeClass('open');
     });
-    $(document).on('keydown.dd', function(e){
+    $(document).unbind('keydown.dd').bind('keydown.dd', function(e){
       if (e.key === 'Escape') $parents.removeClass('open');
     });
   }
 
   // Modalità desktop: niente click handler, usa solo :hover da CSS
   function unbindClicks(){
-    $parents.off('.dd');
-    $(document).off('.dd');
+    $parents.undelegate('.text, .text_only', 'click.dd');
+    $(document).unbind('click.dd').unbind('keydown.dd');
     $parents.removeClass('open');
   }
 
@@ -538,8 +548,6 @@ jQuery(function($){
     else bindMobileClick();          // torna al click
   });
 });
-</script>
-
 </script>
 
 <script type="text/javascript">


### PR DESCRIPTION
## Summary
- fix dazen-skin reader edge navigation regression on older jQuery (1.6.2)
  - replaced unsupported `.on/.off` usage with `.bind/.delegate/.undelegate/.unbind`
  - kept left/right edge click zones and fallback click-area navigation
  - cleaned malformed nested script block that could break handler setup
- prevent cross-deployment admin session interference
  - host-scoped CI session cookie name
  - host-scoped cookie prefix
  - host-scoped Tank Auth autologin cookie name

## Why
- reader edge clicks were not working because handlers were failing at runtime (`$inner.on is not a function` on jQuery 1.6.2).
- logging into one deployment could interfere with the other due to shared cookie names.

## Verification
- DevTools MCP manual verification on localhost reader:
  - right-edge click moves `/page/1` -> `/page/2`
  - left-edge click moves `/page/2` -> `/page/1`
- Automated tests:
  - `./scripts/run-tests.sh` passed

## Files changed
- `content/themes/dazen-skin/views/read.php`
- `application/config/config.php`
- `application/config/tank_auth.php`
