### PR TITLE
fix: isolate demo/prod sessions with host-only cookie domain

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -380,6 +380,8 @@ if ($cookie_host === '')
 $cookie_host = preg_replace('/:\d+$/', '', $cookie_host);
 $cookie_host_hash = substr(md5($cookie_host), 0, 8);
 $config['sess_cookie_name'] = 'ci_session_' . $cookie_host_hash;
+// Enforce host-only cookies so production cookies never bleed into demo (and vice versa).
+$config['cookie_domain'] = '';
 
 
 /*


### PR DESCRIPTION
## Summary
- enforce host-only cookie domain in `application/config/config.php` after loading root config
- keep per-host session cookie naming already in place (`ci_session_<host_hash>`)

## Verification
- `./scripts/run-tests.sh` passes (22 tests, 41 assertions)
- no deployment executed in this change
