### PR TITLE
fix: reset reader scroll when changing chapter pages

### DIFF
--- a/content/themes/dazen-skin/views/read.php
+++ b/content/themes/dazen-skin/views/read.php
@@ -167,6 +167,14 @@ if (!defined('BASEPATH'))
   var gt_key_suggestion = '<?php echo addslashes(_("Use W-A-S-D or the arrow keys to navigate")) ?>';
   var gt_key_tap        = '<?php echo addslashes(_("Double-tap to change page")) ?>';
 
+  function resetReaderScroll()
+  {
+    var readerTop = Math.max(jQuery('#page').offset().top - 6, 0);
+    jQuery(window).scrollTop(readerTop);
+    jQuery('html, body').scrollTop(readerTop);
+    jQuery('#page').scrollLeft(0);
+  }
+
   function changePage(id, noscroll, nohash)
   {
     id = parseInt(id);
@@ -191,7 +199,7 @@ if (!defined('BASEPATH'))
     current_page = id;
 
     jQuery("html, body").stop(true,true);
-    if(!noscroll) jQuery.scrollTo('.panel', 430, {'offset':{'top':-6}});
+    if(!noscroll) resetReaderScroll();
 
     if (pages[id].loaded !== true) {
       jQuery('#page .inner img.open').css({'opacity':'0'}).attr('src', pages[id].url);

--- a/content/themes/default/views/read.php
+++ b/content/themes/default/views/read.php
@@ -98,6 +98,14 @@ if (!defined('BASEPATH'))
 	var gt_key_suggestion = '<?php echo addslashes(_("Use W-A-S-D or the arrow keys to navigate")) ?>';
 	var gt_key_tap = '<?php echo addslashes(_("Double-tap to change page")) ?>';
 
+	function resetReaderScroll()
+	{
+		var readerTop = Math.max(jQuery('#page').offset().top - 6, 0);
+		jQuery(window).scrollTop(readerTop);
+		jQuery('html, body').scrollTop(readerTop);
+		jQuery('#page').scrollLeft(0);
+	}
+
 	function changePage(id, noscroll, nohash)
 	{
 		id = parseInt(id);
@@ -123,7 +131,7 @@ if (!defined('BASEPATH'))
 		current_page = id;
 		next = parseInt(id+1);
 		jQuery("html, body").stop(true,true);
-		if(!noscroll) jQuery.scrollTo('.panel', 430, {'offset':{'top':-6}});
+		if(!noscroll) resetReaderScroll();
 
 		if(pages[id].loaded !== true) {
 			jQuery('#page .inner img.open').css({'opacity':'0'});


### PR DESCRIPTION
## Summary
- reset the reader viewport to the top of the page container when moving between chapter pages
- apply the same behavior in both the default and dazen-skin reader templates
- keep horizontal page scrolling reset as part of the page change flow

## Why
When navigating to the next page with the keyboard, the new page was shown at the same vertical offset as the previous page. This was especially disruptive on long pages because the reader would land mid-image instead of starting from the top.

## Verification
- ./scripts/run-tests.sh
- confirmed that moving to the next page resets the viewport to the top of the reader
