### PR TITLE
fix: reset mobile reader zoom state on page changes

### DIFF
--- a/content/themes/dazen-skin/views/read.php
+++ b/content/themes/dazen-skin/views/read.php
@@ -175,6 +175,17 @@ if (!defined('BASEPATH'))
     jQuery('#page').scrollLeft(0);
   }
 
+  function resetPageView()
+  {
+    jQuery('#page .inner img.open').css({
+      'transform': '',
+      '-webkit-transform': '',
+      'transform-origin': '',
+      '-webkit-transform-origin': ''
+    });
+    resetReaderScroll();
+  }
+
   function changePage(id, noscroll, nohash)
   {
     id = parseInt(id);
@@ -199,7 +210,7 @@ if (!defined('BASEPATH'))
     current_page = id;
 
     jQuery("html, body").stop(true,true);
-    if(!noscroll) resetReaderScroll();
+    if(!noscroll) resetPageView();
 
     if (pages[id].loaded !== true) {
       jQuery('#page .inner img.open').css({'opacity':'0'}).attr('src', pages[id].url);
@@ -208,6 +219,8 @@ if (!defined('BASEPATH'))
     }
 
     resizePage(id);
+
+    if(!noscroll) resetReaderScroll();
 
     if(!nohash) History.pushState(null, null, base_url+'page/' + (current_page + 1));
     document.title = gt_page+' ' + (current_page+1) + ' :: ' + title;

--- a/content/themes/default/views/read.php
+++ b/content/themes/default/views/read.php
@@ -106,6 +106,17 @@ if (!defined('BASEPATH'))
 		jQuery('#page').scrollLeft(0);
 	}
 
+	function resetPageView()
+	{
+		jQuery('#page .inner img.open').css({
+			'transform': '',
+			'-webkit-transform': '',
+			'transform-origin': '',
+			'-webkit-transform-origin': ''
+		});
+		resetReaderScroll();
+	}
+
 	function changePage(id, noscroll, nohash)
 	{
 		id = parseInt(id);
@@ -131,7 +142,7 @@ if (!defined('BASEPATH'))
 		current_page = id;
 		next = parseInt(id+1);
 		jQuery("html, body").stop(true,true);
-		if(!noscroll) resetReaderScroll();
+		if(!noscroll) resetPageView();
 
 		if(pages[id].loaded !== true) {
 			jQuery('#page .inner img.open').css({'opacity':'0'});
@@ -143,6 +154,8 @@ if (!defined('BASEPATH'))
 		}
 
 		resizePage(id);
+
+		if(!noscroll) resetReaderScroll();
 
 		if(!nohash) History.pushState(null, null, base_url+'page/' + (current_page + 1));
 		document.title = gt_page+' ' + (current_page+1) + ' :: ' + title;


### PR DESCRIPTION
## Summary
- clear the carried image transform state when changing reader pages on mobile
- keep the reader viewport reset aligned with the top of the new page after resize
- apply the same behavior in both the default and dazen-skin reader templates

## Why
On mobile, changing page while the current image was zoomed could keep the old zoom/pan state on the next page, which prevented the expected top reset behavior.

## Verification
- ./scripts/run-tests.sh
- browser verification in the local reader under mobile emulation
- confirmed that page changes no longer preserve the previous zoom transform
