### PR TITLE
fix: reset mobile reader zoom on page change

### DIFF
--- a/content/themes/dazen-skin/views/read.php
+++ b/content/themes/dazen-skin/views/read.php
@@ -175,6 +175,27 @@ if (!defined('BASEPATH'))
     jQuery('#page').scrollLeft(0);
   }
 
+  function isMobileReader()
+  {
+    return window.matchMedia('(max-width: 768px)').matches;
+  }
+
+  function resetMobileViewportZoom()
+  {
+    if (!isMobileReader()) return;
+
+    var viewport = document.querySelector('meta[name="viewport"]');
+    if (!viewport) return;
+
+    var baseContent = viewport.getAttribute('content') || 'width=device-width, initial-scale=1';
+    viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1');
+
+    window.setTimeout(function(){
+      viewport.setAttribute('content', baseContent);
+      resetReaderScroll();
+    }, 80);
+  }
+
   function resetPageView()
   {
     jQuery('#page .inner img.open').css({
@@ -183,7 +204,7 @@ if (!defined('BASEPATH'))
       'transform-origin': '',
       '-webkit-transform-origin': ''
     });
-    resetReaderScroll();
+    resetMobileViewportZoom();
   }
 
   function changePage(id, noscroll, nohash)

--- a/content/themes/default/views/read.php
+++ b/content/themes/default/views/read.php
@@ -106,6 +106,29 @@ if (!defined('BASEPATH'))
 		jQuery('#page').scrollLeft(0);
 	}
 
+	function isMobileReader()
+	{
+		return window.matchMedia('(max-width: 768px)').matches;
+	}
+
+	function resetMobileViewportZoom()
+	{
+		if (!isMobileReader())
+			return;
+
+		var viewport = document.querySelector('meta[name="viewport"]');
+		if (!viewport)
+			return;
+
+		var baseContent = viewport.getAttribute('content') || 'width=device-width, initial-scale=1';
+		viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1');
+
+		window.setTimeout(function() {
+			viewport.setAttribute('content', baseContent);
+			resetReaderScroll();
+		}, 80);
+	}
+
 	function resetPageView()
 	{
 		jQuery('#page .inner img.open').css({
@@ -114,7 +137,7 @@ if (!defined('BASEPATH'))
 			'transform-origin': '',
 			'-webkit-transform-origin': ''
 		});
-		resetReaderScroll();
+		resetMobileViewportZoom();
 	}
 
 	function changePage(id, noscroll, nohash)


### PR DESCRIPTION
## Summary
- reset the mobile reader viewport zoom when changing pages
- keep the existing scroll-to-top behavior when opening the next page
- preserve the desktop reader behavior

## Verification
- ran `./scripts/run-tests.sh`
- ran a mobile-emulated browser smoke check for page navigation
