### PR TITLE
fix: restore mobile reader zoom after page change

### DIFF
--- a/content/themes/dazen-skin/views/layouts/reader.php
+++ b/content/themes/dazen-skin/views/layouts/reader.php
@@ -4,7 +4,7 @@
 <head>
 <title><?php echo $template['title']; ?></title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes">
 		<?php
 		if (isset($metacomic))
 		{

--- a/content/themes/dazen-skin/views/read.php
+++ b/content/themes/dazen-skin/views/read.php
@@ -187,13 +187,14 @@ if (!defined('BASEPATH'))
     var viewport = document.querySelector('meta[name="viewport"]');
     if (!viewport) return;
 
-    var baseContent = viewport.getAttribute('content') || 'width=device-width, initial-scale=1';
-    viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1');
+    var baseContent = viewport.dataset.baseContent || viewport.getAttribute('content') || 'width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes';
+    viewport.dataset.baseContent = baseContent;
+    viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no');
 
     window.setTimeout(function(){
       viewport.setAttribute('content', baseContent);
       resetReaderScroll();
-    }, 80);
+    }, 120);
   }
 
   function resetPageView()

--- a/content/themes/default/views/layouts/reader.php
+++ b/content/themes/default/views/layouts/reader.php
@@ -4,7 +4,7 @@
 <head>
 <title><?php echo $template['title']; ?></title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes">
 		<?php
 		if (isset($metacomic))
 		{

--- a/content/themes/default/views/read.php
+++ b/content/themes/default/views/read.php
@@ -120,13 +120,14 @@ if (!defined('BASEPATH'))
 		if (!viewport)
 			return;
 
-		var baseContent = viewport.getAttribute('content') || 'width=device-width, initial-scale=1';
-		viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1');
+		var baseContent = viewport.dataset.baseContent || viewport.getAttribute('content') || 'width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes';
+		viewport.dataset.baseContent = baseContent;
+		viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no');
 
 		window.setTimeout(function() {
 			viewport.setAttribute('content', baseContent);
 			resetReaderScroll();
-		}, 80);
+		}, 120);
 	}
 
 	function resetPageView()


### PR DESCRIPTION
## Summary
- restore mobile reader zoom after changing pages
- keep the existing next-page scroll reset from the top
- preserve desktop reader behavior

## Verification
- ran `./scripts/run-tests.sh`
- ran a mobile-emulated browser smoke check for repeated zoom and page navigation
