### PR TITLE
fix: keep smooth mobile reader navigation when not zoomed

### DIFF
--- a/content/themes/dazen-skin/views/layouts/reader.php
+++ b/content/themes/dazen-skin/views/layouts/reader.php
@@ -4,7 +4,7 @@
 <head>
 <title><?php echo $template['title']; ?></title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 		<?php
 		if (isset($metacomic))
 		{

--- a/content/themes/dazen-skin/views/read.php
+++ b/content/themes/dazen-skin/views/read.php
@@ -180,21 +180,9 @@ if (!defined('BASEPATH'))
     return window.matchMedia('(max-width: 768px)').matches;
   }
 
-  function resetMobileViewportZoom()
+  function isMobileViewportZoomed()
   {
-    if (!isMobileReader()) return;
-
-    var viewport = document.querySelector('meta[name="viewport"]');
-    if (!viewport) return;
-
-    var baseContent = viewport.dataset.baseContent || viewport.getAttribute('content') || 'width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes';
-    viewport.dataset.baseContent = baseContent;
-    viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no');
-
-    window.setTimeout(function(){
-      viewport.setAttribute('content', baseContent);
-      resetReaderScroll();
-    }, 120);
+    return !!(window.visualViewport && window.visualViewport.scale && window.visualViewport.scale > 1.01);
   }
 
   function resetPageView()
@@ -205,7 +193,7 @@ if (!defined('BASEPATH'))
       'transform-origin': '',
       '-webkit-transform-origin': ''
     });
-    resetMobileViewportZoom();
+    resetReaderScroll();
   }
 
   function changePage(id, noscroll, nohash)
@@ -226,6 +214,11 @@ if (!defined('BASEPATH'))
     if (id < 0) {
       current_page = 0;
       id = 0;
+    }
+
+    if (initialized && isMobileReader() && isMobileViewportZoomed() && !noscroll && !nohash && id !== current_page) {
+      window.location.href = base_url + 'page/' + (id + 1);
+      return false;
     }
 
     preload(id);

--- a/content/themes/default/views/layouts/reader.php
+++ b/content/themes/default/views/layouts/reader.php
@@ -4,7 +4,7 @@
 <head>
 <title><?php echo $template['title']; ?></title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<?php
 		if (isset($metacomic))
 		{

--- a/content/themes/default/views/read.php
+++ b/content/themes/default/views/read.php
@@ -111,23 +111,9 @@ if (!defined('BASEPATH'))
 		return window.matchMedia('(max-width: 768px)').matches;
 	}
 
-	function resetMobileViewportZoom()
+	function isMobileViewportZoomed()
 	{
-		if (!isMobileReader())
-			return;
-
-		var viewport = document.querySelector('meta[name="viewport"]');
-		if (!viewport)
-			return;
-
-		var baseContent = viewport.dataset.baseContent || viewport.getAttribute('content') || 'width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes';
-		viewport.dataset.baseContent = baseContent;
-		viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no');
-
-		window.setTimeout(function() {
-			viewport.setAttribute('content', baseContent);
-			resetReaderScroll();
-		}, 120);
+		return !!(window.visualViewport && window.visualViewport.scale && window.visualViewport.scale > 1.01);
 	}
 
 	function resetPageView()
@@ -138,7 +124,7 @@ if (!defined('BASEPATH'))
 			'transform-origin': '',
 			'-webkit-transform-origin': ''
 		});
-		resetMobileViewportZoom();
+		resetReaderScroll();
 	}
 
 	function changePage(id, noscroll, nohash)
@@ -160,6 +146,12 @@ if (!defined('BASEPATH'))
 		if(id < 0){
 			current_page = 0;
 			id = 0;
+		}
+
+		if (initialized && isMobileReader() && isMobileViewportZoomed() && !noscroll && !nohash && id !== current_page)
+		{
+			window.location.href = base_url + 'page/' + (id + 1);
+			return false;
 		}
 
 		preload(id);


### PR DESCRIPTION
## Summary
- restore smooth mobile reader page changes when the viewport is not zoomed
- keep full page navigation only for zoomed mobile page changes so zoom resets cleanly
- remove the viewport meta workaround that blocked repeated pinch zooming

## Verification
- ran `./scripts/run-tests.sh`
- ran a mobile-emulated browser smoke check for normal page changes and zoomed page changes
