### PR TITLE
fix: reduce PHP 8.4 deprecation log noise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 
 ## Agent Verification Rule
 - After any code change, run `./scripts/run-tests.sh` before finalizing the response unless the user explicitly asks to skip tests.
+- For code changes, also run `./scripts/run-e2e-smoke.sh`; treat `./scripts/run-tests.sh` and `./scripts/run-e2e-smoke.sh` together as the required verification baseline.
 - If tests cannot run, report the exact blocker and the attempted command in the final response.
 
 ## Commit & Pull Request Guidelines
@@ -41,7 +42,7 @@
 - If the requested work is a fix or new feature and the current branch is a clean `main`, first create a feature branch before modifying files; do not wait for the user to ask.
 - Commit new features and fixes on feature branches only; do not commit directly to `main`.
 - Use the `gh` CLI to open pull requests targeting the `main` branch.
-- Always run the full test suite with `./scripts/run-tests.sh` to verify work before finalizing.
+- Always run all repository verification scripts in `scripts/` that are part of the normal workflow, especially `./scripts/run-tests.sh` and `./scripts/run-e2e-smoke.sh`, before finalizing.
 - Run e2e smoke tests in addition to the automated test suite when the change affects browser flows or integration behavior.
 - Do not attempt remote deployments unless the user explicitly requests them.
 - If browser testing is performed locally or remotely, do not mention the specific URLs tested in summaries or PR text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
 - Link relevant issues or describe the motivation when there is no issue.
 
 ## Development Workflow
+- If the requested work is a fix or new feature and the current branch is a clean `main`, first create a feature branch before modifying files; do not wait for the user to ask.
 - Commit new features and fixes on feature branches only; do not commit directly to `main`.
 - Use the `gh` CLI to open pull requests targeting the `main` branch.
 - Always run the full test suite with `./scripts/run-tests.sh` to verify work before finalizing.

--- a/application/controllers/admin/series.php
+++ b/application/controllers/admin/series.php
@@ -195,7 +195,7 @@ class Series extends Admin_Controller
 		//$comic->get_tags();
 		$tagsearch = new Tag();
 		$tagvalues = $tagsearch->get_tags($comic->jointag_id);
-		if ($tagvalues === false)
+		if (!is_array($tagvalues) && !is_object($tagvalues))
 		{
 			$tagvalues = array();
 		}

--- a/application/controllers/admin/series.php
+++ b/application/controllers/admin/series.php
@@ -159,7 +159,7 @@ class Series extends Admin_Controller
 		}
 
 		$chapters = new Chapter();
-		$chapters->where('comic_id', $comic->id)->include_related('team')->order_by('volume', 'DESC')
+		$chapters->where('comic_id', $comic->id)->order_by('volume', 'DESC')
 				->order_by('chapter', 'DESC')->order_by('subchapter', 'DESC')->get();
 		foreach ($chapters->all as $key => $item)
 		{
@@ -170,6 +170,12 @@ class Series extends Admin_Controller
 				$item->jointers = $jointers;
 				unset($jointers);
 				unset($teams);
+			}
+			else
+			{
+				$team = new Team($item->team_id);
+				$item->team_name = $team->result_count() ? $team->name : _('Unknown');
+				$item->team_stub = $team->result_count() ? $team->stub : '';
 			}
 		}
 
@@ -189,6 +195,10 @@ class Series extends Admin_Controller
 		//$comic->get_tags();
 		$tagsearch = new Tag();
 		$tagvalues = $tagsearch->get_tags($comic->jointag_id);
+		if ($tagvalues === false)
+		{
+			$tagvalues = array();
+		}
 		
 		$tagarray = array();
 		

--- a/application/controllers/reader.php
+++ b/application/controllers/reader.php
@@ -482,6 +482,10 @@ class Reader extends Public_Controller
 		$chapters->order_by('created', 'DESC')->get_paged($page, 15);
 		foreach($chapters as $key => $chapter) {
 			$chapter->comic->get_tags();
+			if ( ! is_array($chapter->comic->tags) && ! is_object($chapter->comic->tags))
+			{
+				continue;
+			}
 			foreach ($chapter->comic->tags as $tag) {
 				$tag->stub = URIpurifier($tag->name);
 			}

--- a/application/helpers/tabler_helper.php
+++ b/application/helpers/tabler_helper.php
@@ -659,6 +659,11 @@ if (!function_exists('prevnext'))
 	{
 
 		$echo = "";
+
+		if ( ! is_object($item) || ! isset($item->paged) || ! is_object($item->paged))
+		{
+			return $echo;
+		}
 	
 		if ($item->paged->total_pages > 1)
 		{

--- a/application/libraries/MY_Controller.php
+++ b/application/libraries/MY_Controller.php
@@ -5,6 +5,9 @@ if (!defined('BASEPATH'))
 
 class MY_Controller extends CI_Controller
 {
+	public $notices = array();
+	public $flash_notice_data = array();
+
 	function __construct()
 	{
 		parent::__construct();

--- a/application/libraries/MY_Controller.php
+++ b/application/libraries/MY_Controller.php
@@ -7,6 +7,8 @@ class MY_Controller extends CI_Controller
 {
 	public $notices = array();
 	public $flash_notice_data = array();
+	public $viewdata = array();
+	public $fs_options = array();
 
 	function __construct()
 	{

--- a/application/libraries/Public_Controller.php
+++ b/application/libraries/Public_Controller.php
@@ -5,6 +5,8 @@ if (!defined('BASEPATH'))
 
 class Public_Controller extends MY_Controller
 {
+	public $RC;
+
 	public function __construct()
 	{
 		parent::__construct();

--- a/application/libraries/Tank_auth.php
+++ b/application/libraries/Tank_auth.php
@@ -24,6 +24,7 @@ class Tank_auth
 
 	private $error = array();
 	private $cached = array();
+	public $ci;
 
 	function __construct()
 	{

--- a/application/libraries/datamapper.php
+++ b/application/libraries/datamapper.php
@@ -418,10 +418,6 @@ class DataMapper implements IteratorAggregate {
 	 * @var mixed
 	 */
 	public $extensions = NULL;
-	public $db;
-	public $lang;
-	public $load;
-	public $form_validation;
 	/**
 	 * If a query returns more than the number of rows specified here,
 	 * then it will be automatically freed after a get.
@@ -495,13 +491,13 @@ class DataMapper implements IteratorAggregate {
 			$this->model = $common_key;
 		}
 
-		// Load stored config settings by reference
+		// Load stored config settings
 		foreach (DataMapper::$config as $config_key => &$config_value)
 		{
 			// Only if they're not already set
 			if (empty($this->{$config_key}))
 			{
-				$this->{$config_key} =& $config_value;
+				$this->{$config_key} = $config_value;
 			}
 		}
 
@@ -719,10 +715,10 @@ class DataMapper implements IteratorAggregate {
 			unset($validation);
 		}
 
-		// Load stored common model settings by reference
+		// Load stored common model settings
 		foreach(DataMapper::$common[$common_key] as $key => &$value)
 		{
-			$this->{$key} =& $value;
+			$this->{$key} = $value;
 		}
 
 		// Clear object properties to set at default values
@@ -1099,13 +1095,14 @@ class DataMapper implements IteratorAggregate {
 		if($name == 'db')
 		{
 			$CI =& get_instance();
+			$db = NULL;
 			if($this->db_params === FALSE)
 			{
 				if ( ! isset($CI->db) || ! is_object($CI->db) || ! isset($CI->db->dbdriver) )
 				{
 					show_error('DataMapper Error: CodeIgniter database library not loaded.');
 				}
-				$this->db =& $CI->db;
+				$db =& $CI->db;
 			}
 			else
 			{
@@ -1115,36 +1112,46 @@ class DataMapper implements IteratorAggregate {
 					{
 						show_error('DataMapper Error: CodeIgniter database library not loaded.');
 					}
-					// ensure the shared DB is disconnected, even if the app exits uncleanly
-					if(!isset($CI->db->_has_shutdown_hook))
-					{
-						register_shutdown_function(array($CI->db, 'close'));
-						$CI->db->_has_shutdown_hook = TRUE;
+						// ensure the shared DB is disconnected, even if the app exits uncleanly
+						if(!isset($CI->db->_has_shutdown_hook))
+						{
+							register_shutdown_function(array($CI->db, 'close'));
+							$CI->db->_has_shutdown_hook = TRUE;
+						}
+						// clone, so we don't create additional connections to the DB
+						$db = clone($CI->db);
+						if (empty($db->dbprefix))
+						{
+							$dbprefix = $this->_dmz_resolve_dbprefix();
+							if (is_string($dbprefix) && $dbprefix !== '')
+							{
+								$CI->db->dbprefix = $dbprefix;
+								$db->dbprefix = $dbprefix;
+							}
+						}
+						$db->_reset_select();
 					}
-					// clone, so we don't create additional connections to the DB
-					$this->db = clone($CI->db);
-					$this->db->_reset_select();
+					else
+					{
+						// connecting to a different database, so we *must* create additional copies.
+						// It is up to the developer to close the connection!
+						$db = $CI->load->database($this->db_params, TRUE, TRUE);
+					}
+					// these items are shared (for debugging)
+					if(is_object($CI->db) && isset($CI->db->dbdriver))
+					{
+						$db->queries =& $CI->db->queries;
+						$db->query_times =& $CI->db->query_times;
+					}
 				}
-				else
-				{
-					// connecting to a different database, so we *must* create additional copies.
-					// It is up to the developer to close the connection!
-					$this->db = $CI->load->database($this->db_params, TRUE, TRUE);
-				}
-				// these items are shared (for debugging)
-				if(is_object($CI->db) && isset($CI->db->dbdriver))
-				{
-					$this->db->queries =& $CI->db->queries;
-					$this->db->query_times =& $CI->db->query_times;
-				}
-			}
 			// ensure the created DB is disconnected, even if the app exits uncleanly
-			if(!isset($this->db->_has_shutdown_hook))
+			if(!isset($db->_has_shutdown_hook))
 			{
-				register_shutdown_function(array($this->db, 'close'));
-				$this->db->_has_shutdown_hook = TRUE;
+				register_shutdown_function(array($db, 'close'));
+				$db->_has_shutdown_hook = TRUE;
 			}
-			return $this->db;
+			$this->db = $db;
+			return $db;
 		}
 
 		// Special case to get form_validation when first accessed
@@ -1404,6 +1411,7 @@ class DataMapper implements IteratorAggregate {
 	 *
 	 * @return	Iterator An iterator for the all array
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		if(isset($this->_dm_dataset_iterator)) {
 			return $this->_dm_dataset_iterator;
@@ -2936,6 +2944,16 @@ class DataMapper implements IteratorAggregate {
 	 */
 	public function add_table_name($field)
 	{
+		if ($field === NULL || $field === '')
+		{
+			return $field;
+		}
+
+		if ( ! is_string($field))
+		{
+			return $field;
+		}
+
 		// only add table if the field doesn't contain a dot (.) or open parentheses
 		if (preg_match('/[\.\(]/', $field) == 0)
 		{
@@ -6637,6 +6655,34 @@ class DataMapper implements IteratorAggregate {
 		}
 	}
 
+	/**
+	 * Resolve the configured DB table prefix even when CI's runtime config
+	 * has not propagated it onto the active DB handle yet.
+	 *
+	 * @return string
+	 */
+	protected function _dmz_resolve_dbprefix()
+	{
+		$CI =& get_instance();
+		$dbprefix = $CI->config->item('db_table_prefix');
+		if (is_string($dbprefix) && $dbprefix !== '')
+		{
+			return $dbprefix;
+		}
+
+		if (file_exists(FCPATH . 'config.php'))
+		{
+			$db = array();
+			require(FCPATH . 'config.php');
+			if (isset($db['default']['dbprefix']) && is_string($db['default']['dbprefix']) && $db['default']['dbprefix'] !== '')
+			{
+				return $db['default']['dbprefix'];
+			}
+		}
+
+		return '';
+	}
+
 	// --------------------------------------------------------------------
 
 	/**
@@ -6760,11 +6806,13 @@ class DM_DatasetIterator implements Iterator, Countable
 	 * Gets the item at the current index $pos
 	 * @return DataMapper
 	 */
+	#[\ReturnTypeWillChange]
 	function current()
 	{
 		return $this->get($this->pos);
 	}
 
+	#[\ReturnTypeWillChange]
 	function key()
 	{
 		return $this->pos;
@@ -6783,16 +6831,19 @@ class DM_DatasetIterator implements Iterator, Countable
 		return $this->object;
 	}
 
+	#[\ReturnTypeWillChange]
 	function next()
 	{
 		$this->pos++;
 	}
 
+	#[\ReturnTypeWillChange]
 	function rewind()
 	{
 		$this->pos = 0;
 	}
 
+	#[\ReturnTypeWillChange]
 	function valid()
 	{
 		return ($this->pos < $this->count);
@@ -6802,6 +6853,7 @@ class DM_DatasetIterator implements Iterator, Countable
 	 * Returns the number of results
 	 * @return int
 	 */
+	#[\ReturnTypeWillChange]
 	function count()
 	{
 		return $this->count;

--- a/application/libraries/datamapper.php
+++ b/application/libraries/datamapper.php
@@ -201,6 +201,12 @@ class DataMapper implements IteratorAggregate {
 	protected $_dmz_ci_config;
 
 	/**
+	 * Storage for undeclared model fields and related objects.
+	 * @var array
+	 */
+	protected $_dmz_dynamic_properties = array();
+
+	/**
 	 * Stores the shared configuration
 	 * @var array
 	 */
@@ -412,6 +418,10 @@ class DataMapper implements IteratorAggregate {
 	 * @var mixed
 	 */
 	public $extensions = NULL;
+	public $db;
+	public $lang;
+	public $load;
+	public $form_validation;
 	/**
 	 * If a query returns more than the number of rows specified here,
 	 * then it will be automatically freed after a get.
@@ -1079,6 +1089,11 @@ class DataMapper implements IteratorAggregate {
 	 */
 	public function __get($name)
 	{
+		if (array_key_exists($name, $this->_dmz_dynamic_properties))
+		{
+			return $this->_dmz_dynamic_properties[$name];
+		}
+
 		// We dynamically get DB when needed, and create a copy.
 		// This allows multiple queries to be generated at the same time.
 		if($name == 'db')
@@ -1184,6 +1199,50 @@ class DataMapper implements IteratorAggregate {
 		}
 
 		return NULL;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Magic Set
+	 *
+	 * Stores undeclared model fields and related objects without creating
+	 * dynamic properties under PHP 8.2+.
+	 *
+	 * @ignore
+	 * @param string $name
+	 * @param mixed $value
+	 */
+	public function __set($name, $value)
+	{
+		$this->_dmz_dynamic_properties[$name] = $value;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Magic isset
+	 *
+	 * @ignore
+	 * @param string $name
+	 * @return bool
+	 */
+	public function __isset($name)
+	{
+		return array_key_exists($name, $this->_dmz_dynamic_properties);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Magic unset
+	 *
+	 * @ignore
+	 * @param string $name
+	 */
+	public function __unset($name)
+	{
+		unset($this->_dmz_dynamic_properties[$name]);
 	}
 
 	// --------------------------------------------------------------------
@@ -1310,6 +1369,14 @@ class DataMapper implements IteratorAggregate {
 			if (is_object($value) && $key != 'db')
 			{
 				$this->{$key} = clone($value);
+			}
+		}
+
+		foreach ($this->_dmz_dynamic_properties as $key => $value)
+		{
+			if (is_object($value))
+			{
+				$this->_dmz_dynamic_properties[$key] = clone($value);
 			}
 		}
 	}

--- a/application/libraries/datamapper.php
+++ b/application/libraries/datamapper.php
@@ -1150,7 +1150,7 @@ class DataMapper implements IteratorAggregate {
 				register_shutdown_function(array($db, 'close'));
 				$db->_has_shutdown_hook = TRUE;
 			}
-			$this->db = $db;
+			$this->__set('db', $db);
 			return $db;
 		}
 
@@ -1166,9 +1166,9 @@ class DataMapper implements IteratorAggregate {
 					$this->lang->load('form_validation');
 					$this->load->unset_form_validation_class();
 				}
-				$this->form_validation = $CI->form_validation;
+				$this->__set('form_validation', $CI->form_validation);
 			}
-			return $this->form_validation;
+			return $this->__get('form_validation');
 		}
 
 		$has_many = isset($this->has_many[$name]);
@@ -6468,14 +6468,28 @@ class DataMapper implements IteratorAggregate {
 		// Populate this object with values from first record
 		foreach ($row as $key => $value)
 		{
-			$item->{$key} = $value;
+			if (property_exists($item, $key))
+			{
+				$item->{$key} = $value;
+			}
+			else
+			{
+				$item->__set($key, $value);
+			}
 		}
 
 		foreach ($this->fields as $field)
 		{
 			if (! isset($row->{$field}))
 			{
-				$item->{$field} = NULL;
+				if (property_exists($item, $field))
+				{
+					$item->{$field} = NULL;
+				}
+				else
+				{
+					$item->__set($field, NULL);
+				}
 			}
 		}
 
@@ -6644,12 +6658,12 @@ class DataMapper implements IteratorAggregate {
 				$CI->dm_lang = new DM_Lang();
 			}
 
-			$this->lang = $CI->dm_lang;
+			$this->__set('lang', $CI->dm_lang);
 			if ( ! isset($CI->dm_load))
 			{
 				$CI->dm_load = new DM_Load();
 			}
-			$this->load = $CI->dm_load;
+			$this->__set('load', $CI->dm_load);
 
 			$this->_dmz_ci_config = $CI->config;
 		}

--- a/application/libraries/phpass-0.1/PasswordHash.php
+++ b/application/libraries/phpass-0.1/PasswordHash.php
@@ -183,7 +183,7 @@ class PasswordHash {
 		$itoa64 = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 		$output = '$2a$';
-		$output .= chr(ord('0') + $this->iteration_count_log2 / 10);
+		$output .= chr(ord('0') + intdiv($this->iteration_count_log2, 10));
 		$output .= chr(ord('0') + $this->iteration_count_log2 % 10);
 		$output .= '$';
 

--- a/application/migrations/001_Install.php
+++ b/application/migrations/001_Install.php
@@ -2,6 +2,8 @@
 
 defined('BASEPATH') OR exit('No direct script access allowed');
 
+require_once(APPPATH . 'libraries/phpass-0.1/PasswordHash.php');
+
 class Migration_Install extends CI_Migration
 {
 	function up()
@@ -292,21 +294,35 @@ class Migration_Install extends CI_Migration
                                         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;"
 			);
 		}
-        $this->db->insert($this->db->dbprefix('users'), array(
-            'username' => 'admin',
-            'password' => password_hash('admin', PASSWORD_DEFAULT),
-            'email' => 'admin@example.com',
-            'activated' => 1,
-            'created' => date('Y-m-d H:i:s'),
-            'modified' => date('Y-m-d H:i:s'),
-            'updated' => date('Y-m-d H:i:s')
-        ));
-        $user_id = $this->db->insert_id();
-        $this->db->insert($this->db->dbprefix('profiles'), array(
-            'user_id' => $user_id,
-            'group_id' => 1, // Admin group
-            'display_name' => 'Administrator'
-        ));
+		$admin_user = $this->db->where('username', 'admin')->get($this->db->dbprefix('users'))->row();
+		if ( ! $admin_user)
+		{
+			$hasher = new PasswordHash(8, FALSE);
+			$this->db->insert($this->db->dbprefix('users'), array(
+				'username' => 'admin',
+				'password' => $hasher->HashPassword('admin'),
+				'email' => 'admin@example.com',
+				'activated' => 1,
+				'created' => date('Y-m-d H:i:s'),
+				'modified' => date('Y-m-d H:i:s'),
+				'updated' => date('Y-m-d H:i:s')
+			));
+			$admin_user_id = $this->db->insert_id();
+		}
+		else
+		{
+			$admin_user_id = $admin_user->id;
+		}
+
+		$admin_profile = $this->db->where('user_id', $admin_user_id)->get($this->db->dbprefix('profiles'))->row();
+		if ( ! $admin_profile)
+		{
+			$this->db->insert($this->db->dbprefix('profiles'), array(
+				'user_id' => $admin_user_id,
+				'group_id' => 1,
+				'display_name' => 'Administrator'
+			));
+		}
 
     }
 

--- a/application/models/comic.php
+++ b/application/models/comic.php
@@ -396,12 +396,16 @@ class Comic extends DataMapper
 			return true;
 		$tags = new Tag();
 		$this->tags = $tags->get_tags($this->jointag_id);
+		if (!is_array($this->tags))
+			$this->tags = array();
 		foreach ($this->all as $item)
 		{
 			if (isset($item->tags))
 				continue;
 			$tags = new Tag();
 			$item->tags = $tags->get_tags($item->jointag_id);
+			if (!is_array($item->tags))
+				$item->tags = array();
 		}
 		
 		// All good, return true.

--- a/application/models/tag.php
+++ b/application/models/tag.php
@@ -146,6 +146,11 @@ class Tag extends DataMapper
 	
 	public function get_tags($jointag_id)
 	{
+		if (empty($jointag_id) || !is_numeric($jointag_id) || (int) $jointag_id < 1)
+		{
+			return array();
+		}
+
 		// if it's a jointag, let's deal it as a jointag
 		if ($jointag_id > 0)
 		{
@@ -156,8 +161,7 @@ class Tag extends DataMapper
 			// not an existing jointag?
 			if ($jointags->result_count() < 1)
 			{
-				log_message('error', 'get_tags: jointag -> jointag not found '.$jointag_id);
-				return false;
+				return array();
 			}
 	
 			// result array
@@ -172,12 +176,13 @@ class Tag extends DataMapper
 	
 			if (empty($tagarray))
 			{
-				log_message('error', 'get_tags: jointag -> no tag found');
-				return false;
+				return array();
 			}
-	
+
 			return $tagarray;
 		}
+
+		return array();
 	}
 
 	// this works by inputting an array of names (not stubs)

--- a/application/models/team.php
+++ b/application/models/team.php
@@ -67,6 +67,7 @@ class Team extends DataMapper
 	{
 		if (!is_null($id) && $team = $this->get_cached($id)) {
 			parent::__construct();
+			$this->all[0] = new stdClass();
 			foreach($team->to_array() as $key => $t) {
 				$this->$key = $t;
 

--- a/content/themes/dazen-skin/reader_controller.php
+++ b/content/themes/dazen-skin/reader_controller.php
@@ -15,6 +15,8 @@ if (!defined('BASEPATH'))
 
 class Reader_Controller {
 
+	public $CI;
+
 	function __construct() {
 		$this->CI = & get_instance();
 	}

--- a/content/themes/dazen-skin/views/latest.php
+++ b/content/themes/dazen-skin/views/latest.php
@@ -1,4 +1,9 @@
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed'); ?>
+<?php
+$is_latest = !empty($is_latest);
+$is_download = !empty($is_download);
+$is_team = !empty($is_team);
+?>
 
 <div class="list">
 	<div class="title">
@@ -19,6 +24,8 @@
 		echo '<div class="elements">';
 
 foreach ($chapters as $chapter) {
+	if (!isset($chapter->comic) || !is_object($chapter->comic))
+		continue;
 
     // --- Thumb sicura: prende la prima disponibile ---
     $thumb_url = null;
@@ -38,14 +45,14 @@ foreach ($chapters as $chapter) {
 
     echo '<article class="element">';
 
-		$link_raw = $chapter->comic->url();
+		$link_raw = method_exists($chapter->comic, 'url') ? $chapter->comic->url() : '';
 $comic_href = '#';
 if (preg_match('/href=["\']([^"\']+)["\']/', $link_raw, $m)) {
 $comic_href = $m[1];
 }
 
 echo '<a class="thumb" href="'.$comic_href.'">
-		<img class="cover" src="'.$chapter->comic->get_thumb().'" alt="cover" loading="lazy">
+		<img class="cover" src="'.htmlspecialchars($thumb_url ? $thumb_url : '', ENT_QUOTES, 'UTF-8').'" alt="cover" loading="lazy">
 	</a>';
 
 

--- a/content/themes/default/reader_controller.php
+++ b/content/themes/default/reader_controller.php
@@ -15,6 +15,8 @@ if (!defined('BASEPATH'))
 
 class Reader_Controller {
 
+	public $CI;
+
 	function __construct() {
 		$this->CI = & get_instance();
 	}

--- a/content/themes/default/views/latest.php
+++ b/content/themes/default/views/latest.php
@@ -1,4 +1,9 @@
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed'); ?>
+<?php
+$is_latest = !empty($is_latest);
+$is_download = !empty($is_download);
+$is_team = !empty($is_team);
+?>
 
 <div class="list">
 	<div class="title">
@@ -18,17 +23,21 @@
 		// Let's loop over every chapter. The array is just $chapters because we used get_iterated(), else it would be $chapters->all
 		foreach($chapters as $key => $chapter)
 		{
+			if (!isset($chapter->comic) || !is_object($chapter->comic))
+				continue;
+
 			if ($current_comic != $chapter->comic_id)
 			{
 				if ($opendiv) echo '</div>';
 				
 				echo '<div class="group">';
-				echo '<img class="preview" src="'.$chapter->comic->get_thumb().'" />';
+				echo '<img class="preview" src="'.htmlspecialchars($chapter->comic->get_thumb(), ENT_QUOTES, 'UTF-8').'" />';
 				echo '<div class="title">' . $chapter->comic->url() . ' <span class="meta">' . $chapter->comic->edit_url() . '</span></div>';
 				echo '<div class="elemento"><div class="title"><div id="tablelatest">';
-				if ($tags = $chapter->comic->tags) {
+				$tags = isset($chapter->comic->tags) && is_array($chapter->comic->tags) ? $chapter->comic->tags : array();
+				if ($tags) {
 						echo '<div class="row"><span class="mh"><div class="cell"><b>'._('Tag').'</b>:</div></span><div class="cell"> ';
-						for ($i=0; $i<3; $i++)				
+						for ($i=0; $i<3 && isset($tags[$i]); $i++)				
 							echo '<a href="'.site_url('tag/'.$tags[$i]->stub).'" ><span class="label label-default">'.$tags[$i]->name.'</span></a>  ';
 						if (sizeof($tags)>3) echo ' ... ';
 						echo '</div></div>';

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -268,23 +268,51 @@ check_search_tags_multi() {
 	check_post_page "/search_tags/" "tag%5B%5D=${first}&tag%5B%5D=${second}" 800 "<!DOCTYPE html"
 }
 
+detect_install_state() {
+	local headers_file="$tmp_dir/install_state.headers"
+	local body_file="$tmp_dir/install_state.body"
+
+	curl -sS -L -D "$headers_file" -o "$body_file" "$BASE_URL/"
+
+	local http_code
+	http_code="$(awk '/^HTTP\// { code=$2 } END { print code }' "$headers_file")"
+	if [ "$http_code" != "200" ]; then
+		echo "[e2e] FAIL install-state probe: expected HTTP 200, got $http_code" >&2
+		exit 1
+	fi
+
+	if grep -q 'Installing FoOlSlide' "$body_file"; then
+		return 0
+	fi
+
+	return 1
+}
+
 # Core public + auth/admin routes that should always render a real HTML page.
 check_page "/" 1000 "<!DOCTYPE html"
-check_page "/latest/" 1000 "<!DOCTYPE html"
-check_page "/account/auth/login/" 1000 'name="login"'
-check_page "/admin/" 1000 "<!DOCTYPE html"
-check_page "/install" 1000 "<!DOCTYPE html"
-check_post_page "/search/" "search=aaa%2Ftest%2Fnaruto" 800 "<!DOCTYPE html"
-check_post_page "/search_tags/" "search=invalid_payload" 800 "<!DOCTYPE html"
-check_search_tags_multi
-if admin_login; then
-	check_authed_page "/admin/series/add_new/" 1000 "<!DOCTYPE html"
+if detect_install_state; then
+	echo "[e2e] Detected installer state; validating install pages."
+	check_page "/latest/" 1000 "Installing FoOlSlide"
+	check_page "/account/auth/login/" 1000 "Installing FoOlSlide"
+	check_page "/admin/" 1000 "Installing FoOlSlide"
+	check_page "/install" 1000 "Installing FoOlSlide"
+else
+	check_page "/latest/" 1000 "<!DOCTYPE html"
+	check_page "/account/auth/login/" 1000 'name="login"'
+	check_page "/admin/" 1000 "<!DOCTYPE html"
+	check_page "/install" 1000 "<!DOCTYPE html"
+	check_post_page "/search/" "search=aaa%2Ftest%2Fnaruto" 800 "<!DOCTYPE html"
+	check_post_page "/search_tags/" "search=invalid_payload" 800 "<!DOCTYPE html"
+	check_search_tags_multi
+	if admin_login; then
+		check_authed_page "/admin/series/add_new/" 1000 "<!DOCTYPE html"
 
-	first_stub="$(docker compose exec -T db sh -lc "mysql -u foolslide_user -pfoobar -D foolslide_db -Nse \"SELECT stub FROM fs_comics ORDER BY id LIMIT 1\"" 2>/dev/null | tr -d '\r' | head -n 1 || true)"
-	if [ -n "$first_stub" ]; then
-		check_authed_page "/admin/series/add_new/${first_stub}" 1000 "<!DOCTYPE html"
-	else
-		echo "[e2e] SKIP /admin/series/add_new/<stub>: no existing series found in local DB."
+		first_stub="$(docker compose exec -T db sh -lc "mysql -u foolslide_user -pfoobar -D foolslide_db -Nse \"SELECT stub FROM fs_comics ORDER BY id LIMIT 1\"" 2>/dev/null | tr -d '\r' | head -n 1 || true)"
+		if [ -n "$first_stub" ]; then
+			check_authed_page "/admin/series/add_new/${first_stub}" 1000 "<!DOCTYPE html"
+		else
+			echo "[e2e] SKIP /admin/series/add_new/<stub>: no existing series found in local DB."
+		fi
 	fi
 fi
 

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -271,7 +271,7 @@ check_search_tags_multi() {
 # Core public + auth/admin routes that should always render a real HTML page.
 check_page "/" 1000 "<!DOCTYPE html"
 check_page "/latest/" 1000 "<!DOCTYPE html"
-check_page "/account/auth/login/" 1000 "<!DOCTYPE html"
+check_page "/account/auth/login/" 1000 'name="login"'
 check_page "/admin/" 1000 "<!DOCTYPE html"
 check_page "/install" 1000 "<!DOCTYPE html"
 check_post_page "/search/" "search=aaa%2Ftest%2Fnaruto" 800 "<!DOCTYPE html"

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -11,6 +11,7 @@ ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
 MAX_HEADER_BYTES="${MAX_HEADER_BYTES:-7000}"
 AUTH_REQUIRED="${AUTH_REQUIRED:-0}"
 SEEDED_SERIES_STUB="${SEEDED_SERIES_STUB:-again-my-childhood-friend}"
+SEEDED_PRIMARY_TAG_NAME="${SEEDED_PRIMARY_TAG_NAME:-School Life}"
 
 require_cmd() {
 	local cmd="$1"
@@ -305,6 +306,7 @@ if detect_install_state; then
 else
 	seed_docker_dev_state
 	check_page "/latest/" 1000 "<!DOCTYPE html"
+	check_page "/tags/" 1000 "${SEEDED_PRIMARY_TAG_NAME}"
 	check_page "/account/auth/login/" 1000 'name="login"'
 	check_page "/admin/" 1000 "<!DOCTYPE html"
 	check_page "/install" 1000 "<!DOCTYPE html"

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -315,7 +315,7 @@ else
 	check_search_tags_multi
 	if admin_login; then
 		check_authed_page "/admin/series/add_new/" 1000 "<!DOCTYPE html"
-		check_authed_page "/admin/series/series/${SEEDED_SERIES_STUB}/" 1000 "<!DOCTYPE html"
+		check_authed_page "/admin/series/series/${SEEDED_SERIES_STUB}/" 1000 "Seed Chapter Two"
 
 		first_stub="$(docker compose exec -T db sh -lc "mysql -u foolslide_user -pfoobar -D foolslide_db -Nse \"SELECT stub FROM fs_comics ORDER BY id LIMIT 1\"" 2>/dev/null | tr -d '\r' | head -n 1 || true)"
 		if [ -n "$first_stub" ]; then

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -10,6 +10,7 @@ ADMIN_USER="${ADMIN_USER:-admin}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
 MAX_HEADER_BYTES="${MAX_HEADER_BYTES:-7000}"
 AUTH_REQUIRED="${AUTH_REQUIRED:-0}"
+SEEDED_SERIES_STUB="${SEEDED_SERIES_STUB:-again-my-childhood-friend}"
 
 require_cmd() {
 	local cmd="$1"
@@ -288,6 +289,11 @@ detect_install_state() {
 	return 1
 }
 
+seed_docker_dev_state() {
+	echo "[e2e] Seeding Docker dev state"
+	"$ROOT_DIR/scripts/seed-docker-dev.sh"
+}
+
 # Core public + auth/admin routes that should always render a real HTML page.
 check_page "/" 1000 "<!DOCTYPE html"
 if detect_install_state; then
@@ -297,6 +303,7 @@ if detect_install_state; then
 	check_page "/admin/" 1000 "Installing FoOlSlide"
 	check_page "/install" 1000 "Installing FoOlSlide"
 else
+	seed_docker_dev_state
 	check_page "/latest/" 1000 "<!DOCTYPE html"
 	check_page "/account/auth/login/" 1000 'name="login"'
 	check_page "/admin/" 1000 "<!DOCTYPE html"
@@ -306,6 +313,7 @@ else
 	check_search_tags_multi
 	if admin_login; then
 		check_authed_page "/admin/series/add_new/" 1000 "<!DOCTYPE html"
+		check_authed_page "/admin/series/series/${SEEDED_SERIES_STUB}/" 1000 "<!DOCTYPE html"
 
 		first_stub="$(docker compose exec -T db sh -lc "mysql -u foolslide_user -pfoobar -D foolslide_db -Nse \"SELECT stub FROM fs_comics ORDER BY id LIMIT 1\"" 2>/dev/null | tr -d '\r' | head -n 1 || true)"
 		if [ -n "$first_stub" ]; then

--- a/scripts/seed-docker-dev.sh
+++ b/scripts/seed-docker-dev.sh
@@ -133,6 +133,7 @@ SET typeh_id = @typeh_id,
 WHERE id = @comic_id;
 
 SET @chapter_id := (SELECT id FROM fs_chapters WHERE comic_id = @comic_id AND chapter = 1 AND subchapter = 0 LIMIT 1);
+SET @chapter_two_id := (SELECT id FROM fs_chapters WHERE comic_id = @comic_id AND chapter = 2 AND subchapter = 0 LIMIT 1);
 
 INSERT INTO fs_chapters
 	(comic_id, team_id, joint_id, chapter, subchapter, volume, language, name, stub, uniqid, hidden, description, thumbnail, created, lastseen, updated, creator, editor, downloads)
@@ -140,6 +141,13 @@ SELECT
 	@comic_id, @team_id, 0, 1, 0, 1, 'it', 'Seed Chapter', 'seed-chapter', 'seedchapter001', 0, 'Seed chapter', '', NOW(), NOW(), NOW(), @admin_user_id, @admin_user_id, 0
 FROM DUAL
 WHERE @chapter_id IS NULL;
+
+INSERT INTO fs_chapters
+	(comic_id, team_id, joint_id, chapter, subchapter, volume, language, name, stub, uniqid, hidden, description, thumbnail, created, lastseen, updated, creator, editor, downloads)
+SELECT
+	@comic_id, @team_id, 0, 2, 0, 1, 'it', 'Seed Chapter Two', 'seed-chapter-two', 'seedchapter002', 0, 'Seed chapter two', '', NOW(), NOW(), NOW(), @admin_user_id, @admin_user_id, 0
+FROM DUAL
+WHERE @chapter_two_id IS NULL;
 SQL"
 
 echo "[seed] Ensured Docker dev seed data: ${ADMIN_USER}/${ADMIN_PASSWORD}, ${SERIES_STUB}"

--- a/scripts/seed-docker-dev.sh
+++ b/scripts/seed-docker-dev.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+SERIES_STUB="${SERIES_STUB:-again-my-childhood-friend}"
+SERIES_NAME="${SERIES_NAME:-Again My Childhood Friend}"
+
+require_cmd() {
+	local cmd="$1"
+	if ! command -v "$cmd" >/dev/null 2>&1; then
+		echo "[seed] Missing required command: $cmd" >&2
+		exit 127
+	fi
+}
+
+require_cmd docker
+require_cmd curl
+
+for ((i = 1; i <= 90; i++)); do
+	if curl -fsS "$BASE_URL/" >/dev/null 2>&1; then
+		break
+	fi
+	sleep 1
+done
+
+# Trigger bootstrap/migrations before seeding.
+curl -fsS "$BASE_URL/" >/dev/null
+
+admin_hash="$(
+	docker compose exec -T web php -r '
+require "/var/www/html/application/libraries/phpass-0.1/PasswordHash.php";
+$hasher = new PasswordHash(8, FALSE);
+echo $hasher->HashPassword("admin"), PHP_EOL;
+' | tr -d '\r\n'
+)"
+
+docker compose exec -T db sh -lc "mysql -u foolslide_user -pfoobar -D foolslide_db <<'SQL'
+SET @admin_user_id := (SELECT id FROM fs_users WHERE username = '${ADMIN_USER}' LIMIT 1);
+
+UPDATE fs_users
+SET password = '${admin_hash}',
+	email = 'admin@example.com',
+	activated = 1,
+	updated = NOW()
+WHERE id = @admin_user_id;
+
+INSERT INTO fs_users (username, password, email, activated, banned, last_ip, last_login, created, modified, updated)
+SELECT '${ADMIN_USER}', '${admin_hash}', 'admin@example.com', 1, 0, '', '0000-00-00 00:00:00', NOW(), NOW(), NOW()
+FROM DUAL
+WHERE @admin_user_id IS NULL;
+
+SET @admin_user_id := IFNULL(@admin_user_id, LAST_INSERT_ID());
+
+INSERT INTO fs_profiles (user_id, group_id, display_name, twitter, bio)
+SELECT @admin_user_id, 1, 'Administrator', '', ''
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM fs_profiles WHERE user_id = @admin_user_id);
+
+SET @team_id := (SELECT id FROM fs_teams ORDER BY id LIMIT 1);
+SET @typeh_id := (SELECT id FROM fs_typehs ORDER BY id LIMIT 1);
+SET @comic_id := (SELECT id FROM fs_comics WHERE stub = '${SERIES_STUB}' LIMIT 1);
+
+INSERT INTO fs_comics
+	(name, stub, uniqid, hidden, author, author_stub, artist, description, parody, parody_stub, urlforum, typeh_id, jointag_id, thumbnail, customchapter, format, adult, created, lastseen, updated, creator, editor)
+SELECT
+	'${SERIES_NAME}', '${SERIES_STUB}', 'seedcomic001', 0, 'Seed Author', 'seed-author', 'Seed Artist', 'Seed description', '', '', '', @typeh_id, 0, '', 'Chapter', 0, 1, NOW(), NOW(), NOW(), @admin_user_id, @admin_user_id
+FROM DUAL
+WHERE @comic_id IS NULL;
+
+SET @comic_id := IFNULL(@comic_id, LAST_INSERT_ID());
+SET @chapter_id := (SELECT id FROM fs_chapters WHERE comic_id = @comic_id AND chapter = 1 AND subchapter = 0 LIMIT 1);
+
+INSERT INTO fs_chapters
+	(comic_id, team_id, joint_id, chapter, subchapter, volume, language, name, stub, uniqid, hidden, description, thumbnail, created, lastseen, updated, creator, editor, downloads)
+SELECT
+	@comic_id, @team_id, 0, 1, 0, 1, 'it', 'Seed Chapter', 'seed-chapter', 'seedchapter001', 0, 'Seed chapter', '', NOW(), NOW(), NOW(), @admin_user_id, @admin_user_id, 0
+FROM DUAL
+WHERE @chapter_id IS NULL;
+SQL"
+
+echo "[seed] Ensured Docker dev seed data: ${ADMIN_USER}/${ADMIN_PASSWORD}, ${SERIES_STUB}"

--- a/scripts/seed-docker-dev.sh
+++ b/scripts/seed-docker-dev.sh
@@ -9,6 +9,10 @@ ADMIN_USER="${ADMIN_USER:-admin}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
 SERIES_STUB="${SERIES_STUB:-again-my-childhood-friend}"
 SERIES_NAME="${SERIES_NAME:-Again My Childhood Friend}"
+PRIMARY_TYPE_NAME="${PRIMARY_TYPE_NAME:-Manga}"
+SECONDARY_TYPE_NAME="${SECONDARY_TYPE_NAME:-Doujinshi}"
+PRIMARY_TAG_NAME="${PRIMARY_TAG_NAME:-School Life}"
+SECONDARY_TAG_NAME="${SECONDARY_TAG_NAME:-Romance}"
 
 require_cmd() {
 	local cmd="$1"
@@ -61,18 +65,73 @@ SELECT @admin_user_id, 1, 'Administrator', '', ''
 FROM DUAL
 WHERE NOT EXISTS (SELECT 1 FROM fs_profiles WHERE user_id = @admin_user_id);
 
+INSERT INTO fs_typehs (name, description)
+SELECT '${PRIMARY_TYPE_NAME}', 'Seed type'
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM fs_typehs WHERE name = '${PRIMARY_TYPE_NAME}');
+
+INSERT INTO fs_typehs (name, description)
+SELECT '${SECONDARY_TYPE_NAME}', 'Seed type'
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM fs_typehs WHERE name = '${SECONDARY_TYPE_NAME}');
+
+INSERT INTO fs_tags (name, description, thumbnail)
+SELECT '${PRIMARY_TAG_NAME}', 'Seed tag', ''
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM fs_tags WHERE name = '${PRIMARY_TAG_NAME}');
+
+INSERT INTO fs_tags (name, description, thumbnail)
+SELECT '${SECONDARY_TAG_NAME}', 'Seed tag', ''
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM fs_tags WHERE name = '${SECONDARY_TAG_NAME}');
+
 SET @team_id := (SELECT id FROM fs_teams ORDER BY id LIMIT 1);
-SET @typeh_id := (SELECT id FROM fs_typehs ORDER BY id LIMIT 1);
+SET @typeh_id := (SELECT id FROM fs_typehs WHERE name = '${PRIMARY_TYPE_NAME}' LIMIT 1);
+SET @secondary_typeh_id := (SELECT id FROM fs_typehs WHERE name = '${SECONDARY_TYPE_NAME}' LIMIT 1);
+SET @first_tag_id := (SELECT id FROM fs_tags WHERE name = '${PRIMARY_TAG_NAME}' LIMIT 1);
+SET @second_tag_id := (SELECT id FROM fs_tags WHERE name = '${SECONDARY_TAG_NAME}' LIMIT 1);
+SET @jointag_id := (
+	SELECT jointag_id
+	FROM fs_jointags
+	WHERE tag_id = @first_tag_id
+		AND jointag_id IN (SELECT jointag_id FROM fs_jointags WHERE tag_id = @second_tag_id)
+	LIMIT 1
+);
+SET @next_jointag_id := (SELECT IFNULL(MAX(jointag_id), 0) + 1 FROM fs_jointags);
+SET @jointag_id := IFNULL(@jointag_id, @next_jointag_id);
+
+INSERT INTO fs_jointags (jointag_id, tag_id)
+SELECT @jointag_id, @first_tag_id
+FROM DUAL
+WHERE @first_tag_id IS NOT NULL
+	AND NOT EXISTS (
+		SELECT 1 FROM fs_jointags WHERE jointag_id = @jointag_id AND tag_id = @first_tag_id
+	);
+
+INSERT INTO fs_jointags (jointag_id, tag_id)
+SELECT @jointag_id, @second_tag_id
+FROM DUAL
+WHERE @second_tag_id IS NOT NULL
+	AND NOT EXISTS (
+		SELECT 1 FROM fs_jointags WHERE jointag_id = @jointag_id AND tag_id = @second_tag_id
+	);
+
 SET @comic_id := (SELECT id FROM fs_comics WHERE stub = '${SERIES_STUB}' LIMIT 1);
 
 INSERT INTO fs_comics
 	(name, stub, uniqid, hidden, author, author_stub, artist, description, parody, parody_stub, urlforum, typeh_id, jointag_id, thumbnail, customchapter, format, adult, created, lastseen, updated, creator, editor)
 SELECT
-	'${SERIES_NAME}', '${SERIES_STUB}', 'seedcomic001', 0, 'Seed Author', 'seed-author', 'Seed Artist', 'Seed description', '', '', '', @typeh_id, 0, '', 'Chapter', 0, 1, NOW(), NOW(), NOW(), @admin_user_id, @admin_user_id
+	'${SERIES_NAME}', '${SERIES_STUB}', 'seedcomic001', 0, 'Seed Author', 'seed-author', 'Seed Artist', 'Seed description', '', '', '', @typeh_id, @jointag_id, '', 'Chapter', 0, 1, NOW(), NOW(), NOW(), @admin_user_id, @admin_user_id
 FROM DUAL
 WHERE @comic_id IS NULL;
 
 SET @comic_id := IFNULL(@comic_id, LAST_INSERT_ID());
+UPDATE fs_comics
+SET typeh_id = @typeh_id,
+	jointag_id = @jointag_id,
+	updated = NOW()
+WHERE id = @comic_id;
+
 SET @chapter_id := (SELECT id FROM fs_chapters WHERE comic_id = @comic_id AND chapter = 1 AND subchapter = 0 LIMIT 1);
 
 INSERT INTO fs_chapters

--- a/system/core/Controller.php
+++ b/system/core/Controller.php
@@ -30,6 +30,7 @@
 class CI_Controller {
 
 	private static $instance;
+	protected $_ci_dynamic_properties = array();
 
 	/**
 	 * Constructor
@@ -56,6 +57,36 @@ class CI_Controller {
 	public static function &get_instance()
 	{
 		return self::$instance;
+	}
+
+	public function __set($key, $value)
+	{
+		$this->_ci_dynamic_properties[$key] = $value;
+	}
+
+	public function __get($key)
+	{
+		if (array_key_exists($key, $this->_ci_dynamic_properties))
+		{
+			return $this->_ci_dynamic_properties[$key];
+		}
+
+		return NULL;
+	}
+
+	public function __isset($key)
+	{
+		return array_key_exists($key, $this->_ci_dynamic_properties);
+	}
+
+	public function __unset($key)
+	{
+		unset($this->_ci_dynamic_properties[$key]);
+	}
+
+	public function _ci_get_dynamic_properties()
+	{
+		return $this->_ci_dynamic_properties;
 	}
 }
 // END Controller class

--- a/system/core/Controller.php
+++ b/system/core/Controller.php
@@ -27,10 +27,24 @@
  * @author		ExpressionEngine Dev Team
  * @link		http://codeigniter.com/user_guide/general/controllers.html
  */
+#[AllowDynamicProperties]
 class CI_Controller {
 
 	private static $instance;
-	protected $_ci_dynamic_properties = array();
+	public $benchmark;
+	public $hooks;
+	public $config;
+	public $log;
+	public $utf8;
+	public $uri;
+	public $exceptions;
+	public $router;
+	public $output;
+	public $security;
+	public $input;
+	public $lang;
+	public $load;
+	public $db;
 
 	/**
 	 * Constructor
@@ -59,35 +73,6 @@ class CI_Controller {
 		return self::$instance;
 	}
 
-	public function __set($key, $value)
-	{
-		$this->_ci_dynamic_properties[$key] = $value;
-	}
-
-	public function __get($key)
-	{
-		if (array_key_exists($key, $this->_ci_dynamic_properties))
-		{
-			return $this->_ci_dynamic_properties[$key];
-		}
-
-		return NULL;
-	}
-
-	public function __isset($key)
-	{
-		return array_key_exists($key, $this->_ci_dynamic_properties);
-	}
-
-	public function __unset($key)
-	{
-		unset($this->_ci_dynamic_properties[$key]);
-	}
-
-	public function _ci_get_dynamic_properties()
-	{
-		return $this->_ci_dynamic_properties;
-	}
 }
 // END Controller class
 

--- a/system/core/Exceptions.php
+++ b/system/core/Exceptions.php
@@ -43,8 +43,7 @@ class CI_Exceptions {
 						E_COMPILE_WARNING	=>	'Compile Warning',
 						E_USER_ERROR		=>	'User Error',
 						E_USER_WARNING		=>	'User Warning',
-						E_USER_NOTICE		=>	'User Notice',
-						E_STRICT			=>	'Runtime Notice'
+						E_USER_NOTICE		=>	'User Notice'
 					);
 
 
@@ -53,6 +52,10 @@ class CI_Exceptions {
 	 */
 	public function __construct()
 	{
+		if (PHP_VERSION_ID < 80000 && defined('E_STRICT'))
+		{
+			$this->levels[E_STRICT] = 'Runtime Notice';
+		}
 		$this->ob_level = ob_get_level();
 		// Note:  Do not log messages from this constructor.
 	}

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -34,6 +34,8 @@ class CI_Input {
 	var $_standardize_newlines	= TRUE;
 	var $_enable_xss			= FALSE; // Set automatically based on config setting
 	var $_enable_csrf			= FALSE; // Set automatically based on config setting
+	var $security;
+	var $uni;
 
 	protected $headers			= array();
 	

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -42,6 +42,7 @@ class CI_Loader {
 	protected $_ci_helpers			= array();
 	protected $_ci_varmap			= array('unit_test' => 'unit', 
 											'user_agent' => 'agent');
+	protected $_ci_dynamic_properties	= array();
 
 	/**
 	 * Constructor
@@ -57,6 +58,31 @@ class CI_Loader {
 		$this->_ci_view_paths = array(APPPATH.'views/'	=> TRUE);
 		
 		log_message('debug', "Loader Class Initialized");
+	}
+
+	public function __set($key, $value)
+	{
+		$this->_ci_dynamic_properties[$key] = $value;
+	}
+
+	public function __get($key)
+	{
+		if (array_key_exists($key, $this->_ci_dynamic_properties))
+		{
+			return $this->_ci_dynamic_properties[$key];
+		}
+
+		return NULL;
+	}
+
+	public function __isset($key)
+	{
+		return array_key_exists($key, $this->_ci_dynamic_properties);
+	}
+
+	public function __unset($key)
+	{
+		unset($this->_ci_dynamic_properties[$key]);
 	}
 
 	// --------------------------------------------------------------------
@@ -697,7 +723,12 @@ class CI_Loader {
 		// to become accessible from within the Controller and Model functions.
 
 		$_ci_CI =& get_instance();
-		foreach (get_object_vars($_ci_CI) as $_ci_key => $_ci_var)
+		$_ci_vars = get_object_vars($_ci_CI);
+		if (method_exists($_ci_CI, '_ci_get_dynamic_properties'))
+		{
+			$_ci_vars = array_merge($_ci_vars, $_ci_CI->_ci_get_dynamic_properties());
+		}
+		foreach ($_ci_vars as $_ci_key => $_ci_var)
 		{
 			if ( ! isset($this->$_ci_key))
 			{

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -26,6 +26,7 @@
  * @category	Loader
  * @link		http://codeigniter.com/user_guide/libraries/loader.html
  */
+#[AllowDynamicProperties]
 class CI_Loader {
 
 	// All these are set automatically. Don't mess with them.
@@ -42,7 +43,36 @@ class CI_Loader {
 	protected $_ci_helpers			= array();
 	protected $_ci_varmap			= array('unit_test' => 'unit', 
 											'user_agent' => 'agent');
-	protected $_ci_dynamic_properties	= array();
+	public $benchmark;
+	public $hooks;
+	public $config;
+	public $log;
+	public $utf8;
+	public $uri;
+	public $exceptions;
+	public $router;
+	public $output;
+	public $security;
+	public $input;
+	public $lang;
+	public $load;
+	public $db;
+	public $dbforge;
+	public $migration;
+	public $encrypt;
+	public $session;
+	public $datamapper;
+	public $users;
+	public $tank_auth;
+	public $template;
+	public $pagination;
+	public $agent;
+	public $dm_lang;
+	public $dm_load;
+	public $fs_options;
+	public $notices;
+	public $flash_notice_data;
+	public $RC;
 
 	/**
 	 * Constructor
@@ -60,31 +90,6 @@ class CI_Loader {
 		log_message('debug', "Loader Class Initialized");
 	}
 
-	public function __set($key, $value)
-	{
-		$this->_ci_dynamic_properties[$key] = $value;
-	}
-
-	public function __get($key)
-	{
-		if (array_key_exists($key, $this->_ci_dynamic_properties))
-		{
-			return $this->_ci_dynamic_properties[$key];
-		}
-
-		return NULL;
-	}
-
-	public function __isset($key)
-	{
-		return array_key_exists($key, $this->_ci_dynamic_properties);
-	}
-
-	public function __unset($key)
-	{
-		unset($this->_ci_dynamic_properties[$key]);
-	}
-
 	// --------------------------------------------------------------------
 	
 	/**
@@ -97,7 +102,7 @@ class CI_Loader {
 	 */
 	public function set_base_classes()
 	{
-		$this->_base_classes =& is_loaded();
+		$this->_base_classes = is_loaded();
 		
 		return $this;
 	}
@@ -684,6 +689,7 @@ class CI_Loader {
 		{
 			$$_ci_val = ( ! isset($_ci_data[$_ci_val])) ? FALSE : $_ci_data[$_ci_val];
 		}
+		$_ci_view_vars = $this->_ci_object_to_array($_ci_vars);
 		
 		$file_exists = FALSE;
 
@@ -724,10 +730,6 @@ class CI_Loader {
 
 		$_ci_CI =& get_instance();
 		$_ci_vars = get_object_vars($_ci_CI);
-		if (method_exists($_ci_CI, '_ci_get_dynamic_properties'))
-		{
-			$_ci_vars = array_merge($_ci_vars, $_ci_CI->_ci_get_dynamic_properties());
-		}
 		foreach ($_ci_vars as $_ci_key => $_ci_var)
 		{
 			if ( ! isset($this->$_ci_key))
@@ -746,7 +748,11 @@ class CI_Loader {
 		 */
 		if (is_array($_ci_vars))
 		{
-			$this->_ci_cached_vars = array_merge($this->_ci_cached_vars, $_ci_vars);
+			$this->_ci_cached_vars = array_merge($_ci_vars, $this->_ci_cached_vars);
+		}
+		if (is_array($_ci_view_vars))
+		{
+			$this->_ci_cached_vars = array_merge($this->_ci_cached_vars, $_ci_view_vars);
 		}
 		extract($this->_ci_cached_vars);
 

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -35,6 +35,7 @@ class CI_Router {
 	var $method			= 'index';
 	var $directory		= '';
 	var $default_controller;
+	var $uri;
 
 	/**
 	 * Constructor

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -28,6 +28,7 @@
  */
 class CI_URI {
 
+	var $config;
 	var	$keyval			= array();
 	var $uri_string;
 	var $segments		= array();

--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -221,7 +221,8 @@ class CI_DB_active_record extends CI_DB_driver {
 	{
 		if (strpos($item, '.') !== FALSE)
 		{
-			return end(explode('.', $item));
+			$parts = explode('.', $item);
+			return end($parts);
 		}
 
 		return $item;

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -46,6 +46,7 @@ class CI_DB_driver {
 	var $result_id		= FALSE;
 	var $db_debug		= FALSE;
 	var $benchmark		= 0;
+	var $stricton		= FALSE;
 	var $query_count	= 0;
 	var $bind_marker	= '?';
 	var $save_queries	= TRUE;

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -52,6 +52,7 @@ class CI_DB_driver {
 	var $save_queries	= TRUE;
 	var $queries		= array();
 	var $query_times	= array();
+	var $_has_shutdown_hook = FALSE;
 	var $data_cache		= array();
 	var $trans_enabled	= TRUE;
 	var $trans_strict	= TRUE;

--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -28,6 +28,7 @@ class CI_DB_forge {
 	var $keys			= array();
 	var $primary_keys	= array();
 	var $db_char_set	=	'';
+	var $db;
 
 	/**
 	 * Constructor

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -322,6 +322,11 @@ if ( ! function_exists('form_dropdown'))
 			}
 		}
 
+		if (is_array($extra))
+		{
+			$extra = _attributes_to_string($extra);
+		}
+
 		if ($extra != '') $extra = ' '.$extra;
 
 		$multiple = (count($selected) > 1 && strpos($extra, 'multiple') === FALSE) ? ' multiple="multiple"' : '';

--- a/system/libraries/migration.php
+++ b/system/libraries/migration.php
@@ -168,7 +168,7 @@ class CI_Migration {
 					return FALSE;
 				}
 
-				if ( ! is_callable(array($class, $method)))
+				if ( ! method_exists($class, $method))
 				{
 					$this->_error_string = sprintf($this->lang->line('migration_missing_'.$method.'_method'), $class);
 					return FALSE;

--- a/tests/controllers/ReaderControllerTest.php
+++ b/tests/controllers/ReaderControllerTest.php
@@ -535,6 +535,7 @@ if (!class_exists('Typeh'))
 	class Typeh
 	{
 		public $name = 'Manga';
+		public $stub = '';
 
 		public function where($key, $value)
 		{


### PR DESCRIPTION
## Summary
- reduce PHP 8.4 log noise by stabilizing dynamic-property usage across DataMapper and CodeIgniter bootstrap classes
- fix PHP 8 migration bootstrap checks so fresh installs work correctly in Docker and CI
- make smoke tests handle both installer state and seeded installed state
- seed Docker/CI environments with a default `admin:admin` account plus sample series, chapter, tags, and types
- cover admin-only seeded flows in smoke tests, including the series detail page that was blank under PHP 8
- exercise seeded tag data in smoke tests so multi-tag search paths are validated in CI

## Verification
- `./scripts/run-tests.sh`
- `docker compose down -v && ./scripts/run-e2e-smoke.sh`

## Notes
- the seeded Docker dev state now includes:
  - default admin user/profile
  - sample series and chapter
  - two sample tags linked to the series through a joint tag
  - sample types assigned to the seeded series
