### PR TITLE
fix: restore admin series creation and uploads

### DIFF
--- a/application/controllers/admin/series.php
+++ b/application/controllers/admin/series.php
@@ -764,9 +764,15 @@ class Series extends Admin_Controller
 		}
 	}
 
-	function upload()
+	function upload($upload_type = "")
 	{
 		$info = array();
+
+		if (!isset($_FILES['Filedata']) || !isset($_FILES['Filedata']['tmp_name']))
+		{
+			$this->output->set_output(json_encode($info));
+			return true;
+		}
 
 		// compatibility for flash uploader and browser not supporting multiple upload
 		if (is_array($_FILES['Filedata']) && !is_array($_FILES['Filedata']['tmp_name']))
@@ -785,6 +791,11 @@ class Series extends Admin_Controller
 				$pages = $this->files_model->page($_FILES['Filedata']['tmp_name'][$file], $_FILES['Filedata']['name'][$file], $this->input->post('chapter_id'));
 			else
 				$pages = $this->files_model->compressed_chapter($_FILES['Filedata']['tmp_name'][$file], $_FILES['Filedata']['name'][$file], $this->input->post('chapter_id'));
+
+			if (!$pages || !is_array($pages))
+			{
+				continue;
+			}
 
 			foreach ($pages as $page)
 			{

--- a/application/datamapper/tools.php
+++ b/application/datamapper/tools.php
@@ -21,9 +21,12 @@ class tools
 		$CI = & get_instance();
 		$CI->load->helper('inflector');
 		log_message('info', print_r($input, true));
-		if(isset($input->stub)) $val = $input->stub;
-		else if(isset($input->to_stub)) $val = $input->to_stub;
-		else $val = $input->name;
+		if (isset($input->stub) && trim((string) $input->stub) !== '')
+			$val = $input->stub;
+		else if (isset($input->to_stub) && trim((string) $input->to_stub) !== '')
+			$val = $input->to_stub;
+		else
+			$val = $input->name;
 		$val = strtolower(str_replace(" ", "_", trim($val)));
 		$val = slugify($val);
 		return preg_replace('/[^a-z-0-9_]/i', '', $val);

--- a/application/models/comic.php
+++ b/application/models/comic.php
@@ -523,10 +523,11 @@ class Comic extends DataMapper
 	 */
 	public function update_comic_db($data = array())
 	{
+		$is_new = !(isset($data["id"]) && $data['id'] != '');
 
 		// Check if we're updating or creating a new series by looking at $data["id"].
 		// False is returned if the chapter ID was not found.
-		if (isset($data["id"]) && $data['id'] != '')
+		if (!$is_new)
 		{
 			$this->where("id", $data["id"])->get();
 			if ($this->result_count() == 0)
@@ -552,7 +553,7 @@ class Comic extends DataMapper
 
 		// always set the editor name
 		$this->editor = $this->logged_id();
-		$input_stub = $data["stub"];
+		$input_stub = isset($data["stub"]) ? trim($data["stub"]) : '';
 		$has_custom_slug = isset($data["has_custom_slug"]) && $data["has_custom_slug"] == 1;
 
 		// Unset sensible variables
@@ -573,15 +574,18 @@ class Comic extends DataMapper
 		// Loop over the array and assign values to the variables.
 		foreach ($data as $key => $value)
 		{
-			if (($key !== 'tags') || ($key !== 'parody')) 
+			if (($key !== 'tags') && ($key !== 'parody')) 
 				$this->$key = $value;
 		}
 
-		// Double check that we have all the necessary automated variables
-		if (!isset($this->uniqid))
+		// Double check that we have all the necessary automated variables.
+		if (!isset($this->uniqid) || $this->uniqid === '')
 			$this->uniqid = uniqid();
-		if (!isset($this->stub))
+		if ($is_new || trim((string) $this->stub) === '')
+		{
+			$this->to_stub = $this->name;
 			$this->stub = $this->stub();
+		}
 
 		// Create a new stub if the name has changed
 		if (isset($old_name) && isset($old_stub) && ($old_name != $this->name))
@@ -593,7 +597,7 @@ class Comic extends DataMapper
 		}
 		
 		// stub changed by user
-		if ($has_custom_slug & $input_stub != "" && ($this->stub != $input_stub || (isset($old_stub) && $old_stub != $input_stub)))
+		if ($has_custom_slug && $input_stub !== "" && ($this->stub != $input_stub || (isset($old_stub) && $old_stub != $input_stub)))
 		{
 			$this->stub = $input_stub;
 			$this->stub = $this->stub();

--- a/application/models/jointag.php
+++ b/application/models/jointag.php
@@ -59,63 +59,76 @@ class Jointag extends DataMapper {
 
 	public function add_jointag_via_name($tags) {
 		$result = array();
-		
-		//tags is an array of ordered numbers that must be changed with an array of tag names  
+
 		$alltags = new Tag();
-		$alltags->order_by('name','ASC')->get();
-		
-		$newtags = array();
-		foreach ($alltags->all as $new) 
+		$alltags->order_by('name', 'ASC')->get();
+
+		$ordered_tag_ids = array();
+		foreach ($alltags->all as $tag)
 		{
-			$newtags[] = $new->name;
+			$ordered_tag_ids[] = (int) $tag->id;
 		}
-		
-		foreach ($tags as $key => $value)
+
+		foreach ($tags as $value)
 		{
-			$tags[$key] = $newtags[$value-1];
-		} 
-		
-		foreach ($tags as $tag) {
-			$ta = new Tag();
-			$ta->where('name', $tag)->get();
-			if ($ta->result_count() == 0) {
-				set_notice('error', _('One of the named tags doesn\'t exist.'. $tag));
-				log_message('error', 'add_joint_via_name: tag does not exist');
+			if ($value === '' || $value === NULL || $value === 0 || $value === '0')
+			{
+				continue;
+			}
+
+			$tag = new Tag();
+			if (is_numeric($value))
+			{
+				$numeric_value = (int) $value;
+				$tag->where('id', $numeric_value)->get();
+				if ($tag->result_count() == 0 && isset($ordered_tag_ids[$numeric_value - 1]))
+				{
+					$tag = new Tag();
+					$tag->where('id', $ordered_tag_ids[$numeric_value - 1])->get();
+				}
+			}
+			else
+			{
+				$tag->where('name', $value)->get();
+			}
+
+			if ($tag->result_count() == 0)
+			{
+				set_notice('error', _('One of the named tags doesn\'t exist.'));
+				log_message('error', 'add_jointag_via_name: tag does not exist');
 				return false;
 			}
-			$result[] = $ta->id;
+
+			$result[] = (int) $tag->id;
 		}
+
 		return $this->add_jointag($result);
 	}
 
 	// $tags is an array of IDs
 	public function add_jointag($tags) {
-		if (!$result = $this->check_jointag($tags)) {
-			$maxjointag = new Jointag();
-			/**
-			 * @todo select_max returns an error:
-			 * ERROR - 2011-05-31 19:58:16 --> Severity: Notice --> Undefined offset: 0 /var/www/manga/beta3/system/database/DB_active_rec.php 1719
-			*/
-			//$maxjoint->select_max('joint_id')->get();
-			$maxjointag->order_by('jointag_id', 'DESC')->limit(1)->get();
-			$max = $maxjointag->jointag_id + 1;
+		$tags = array_map('intval', (array) $tags);
+		$tags = array_values(array_unique(array_filter($tags)));
+		sort($tags);
 
-			foreach ($tags as $key => $tag) {
-				$jointag = new Jointag();
-				$jointag->jointag_id = $max;
-				$jointag->tag_id = $tag;
-				if (!$jointag->save()) {
-					if ($jointag->valid) {
-						set_notice('error', _('Check that you have inputted all the required fields.'));
-						log_message('error', 'add_jointag: validation failed');
-					}
-					else {
-						set_notice('error', _('Couldn\'t save jointag to database due to an unknown error.'));
-						log_message('error', 'add_jointag: saving failed');
-					}
+		if (empty($tags))
+		{
+			return false;
+		}
+
+		if (!$result = $this->check_jointag($tags)) {
+			$CI = & get_instance();
+			$max_row = $CI->db->select_max('jointag_id')->get('jointags')->row();
+			$max = ((int) $max_row->jointag_id) + 1;
+
+			foreach ($tags as $tag) {
+				if (!$CI->db->insert('jointags', array('jointag_id' => $max, 'tag_id' => $tag))) {
+					set_notice('error', _('Couldn\'t save jointag to database due to an unknown error.'));
+					log_message('error', 'add_jointag: saving failed');
 					return false;
 				}
 			}
+
 			return $max;
 		}
 		return $result;

--- a/application/models/page.php
+++ b/application/models/page.php
@@ -300,12 +300,14 @@ class Page extends DataMapper
 	 */
 	public function update_page_db($data = array())
 	{
+		$CI = & get_instance();
+
 		// Check if we're updating or creating a new entry by looking at $data["id"].
 		// False is returned if the ID was not found.
-		if (isset($data["id"]))
+		if (isset($data["id"]) && $data["id"] !== '')
 		{
 			$this->where("id", $data["id"])->get();
-			if ($chapter->result_count() == 0)
+			if ($this->result_count() == 0)
 			{
 				set_notice('error', _('There isn\'t a page in the database related to this ID.'));
 				log_message('error', 'update_page_db: failed to find requested id');
@@ -354,20 +356,36 @@ class Page extends DataMapper
 			$this->$key = $value;
 		}
 
-		// let's save and give some error check. Push false if fail, true if good.
-		$success = $this->save();
+		$payload = array(
+			'chapter_id' => (int) $this->chapter_id,
+			'filename' => $this->filename,
+			'hidden' => isset($this->hidden) ? (int) $this->hidden : 0,
+			'lastseen' => isset($this->lastseen) ? $this->lastseen : NULL,
+			'creator' => $this->creator,
+			'editor' => $this->editor,
+			'width' => (int) $this->width,
+			'height' => (int) $this->height,
+			'mime' => $this->mime,
+			'size' => (int) $this->size,
+		);
+
+		if (isset($this->id) && $this->id !== '' && $this->id !== NULL)
+		{
+			$success = $CI->db->where('id', $this->id)->update('pages', $payload);
+		}
+		else
+		{
+			$success = $CI->db->insert('pages', $payload);
+			if ($success)
+			{
+				$this->id = $CI->db->insert_id();
+			}
+		}
+
 		if (!$success)
 		{
-			if (!$this->valid)
-			{
-				set_notice('error', _('Check that you have inputted all the required fields.'));
-				log_message('error', 'update_page_db: failed validation');
-			}
-			else
-			{
-				set_notice('error', _('Failed to write to database for unknown reasons.'));
-				log_message('error', 'update_page_db: failed to save');
-			}
+			set_notice('error', _('Failed to write to database for unknown reasons.'));
+			log_message('error', 'update_page_db: failed to save');
 			return false;
 		}
 		else

--- a/application/views/admin/series/chapter.php
+++ b/application/views/admin/series/chapter.php
@@ -121,7 +121,7 @@ $this->buttoner[] = array(
 <script type="text/javascript">
 	jQuery(function () {
 		jQuery('#fileupload').fileupload({
-			url: '<?php echo site_url('/admin/series/upload/compressed_chapter'); ?>',
+			url: '<?php echo site_url('/admin/series/upload'); ?>',
 			sequentialUploads: true,
 			formData: [
 				{

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -31,6 +31,11 @@ if ! docker compose version >/dev/null 2>&1; then
 	exit 127
 fi
 
+db_query() {
+	local sql="$1"
+	docker compose exec -T db sh -lc "mysql -u foolslide_user -pfoobar -D foolslide_db -Nse \"$sql\"" 2>/dev/null | tr -d '\r'
+}
+
 echo "[e2e] Starting Docker Compose stack"
 docker compose up -d --build
 
@@ -289,6 +294,122 @@ check_authed_page() {
 	validate_header_size "$headers_file" "$path"
 }
 
+check_authed_post_redirect() {
+	local path="$1"
+	local post_data="$2"
+	local expected_location_fragment="$3"
+
+	local safe_name
+	safe_name="$(echo "authed_post_${path}_${expected_location_fragment}" | tr '/:?&= ' '_')"
+	local headers_file="$tmp_dir/${safe_name}.headers"
+	local body_file="$tmp_dir/${safe_name}.body"
+
+	curl -sS -D "$headers_file" -o "$body_file" \
+		-c "$COOKIE_JAR" -b "$COOKIE_JAR" \
+		-X POST \
+		-H 'Content-Type: application/x-www-form-urlencoded' \
+		--data "$post_data" \
+		"$BASE_URL$path"
+
+	local http_code
+	http_code="$(awk '/^HTTP\// { code=$2 } END { print code }' "$headers_file")"
+	local location
+	location="$(awk 'BEGIN{IGNORECASE=1} /^Location:/ { val=$2 } END { sub(/\r$/, "", val); print val }' "$headers_file")"
+
+	echo "[e2e] AUTH POST $path -> status=$http_code location=$location"
+
+	if [ "$http_code" != "302" ]; then
+		echo "[e2e] FAIL AUTH POST $path: expected HTTP 302, got $http_code" >&2
+		exit 1
+	fi
+
+	if [[ "$location" != *"$expected_location_fragment"* ]]; then
+		echo "[e2e] FAIL AUTH POST $path: expected redirect containing '$expected_location_fragment', got '$location'" >&2
+		exit 1
+	fi
+
+	validate_header_size "$headers_file" "$path"
+}
+
+create_series_via_admin() {
+	local series_name="$1"
+	local tag_value="$2"
+	local data="name=${series_name// /+}&stub=&typeh_id=1&parody=&urlforum=&description=&customchapter=&format=1&author=&artist=&author_stub=&parody_stub=&id=&tags%5B%5D=${tag_value}&tags%5B%5D=0&licensed%5B%5D=&submit=Save"
+
+	curl -sS -o /dev/null \
+		-c "$COOKIE_JAR" -b "$COOKIE_JAR" \
+		-X POST \
+		-H 'Content-Type: application/x-www-form-urlencoded' \
+		--data "$data" \
+		"$BASE_URL/admin/series/add_new/"
+
+	local stub
+	stub="$(db_query "SELECT stub FROM fs_comics WHERE name = '${series_name}' ORDER BY id DESC LIMIT 1;")"
+	if [ -z "$stub" ]; then
+		echo "[e2e] FAIL create series '${series_name}': no comic row found." >&2
+		exit 1
+	fi
+
+	if [ "$stub" = "0" ] || [ "$stub" = "" ]; then
+		echo "[e2e] FAIL create series '${series_name}': stub was not generated." >&2
+		exit 1
+	fi
+
+	check_authed_page "/admin/series/series/${stub}/" 1000 "${series_name}" >&2
+	check_authed_page "/admin/series/add_new/${stub}" 1000 "<!DOCTYPE html" >&2
+
+	echo "$stub"
+}
+
+create_chapter_via_admin() {
+	local series_stub="$1"
+	local chapter_number="$2"
+	local chapter_name="$3"
+	local comic_id
+	comic_id="$(db_query "SELECT id FROM fs_comics WHERE stub = '${series_stub}' ORDER BY id DESC LIMIT 1;")"
+	if [ -z "$comic_id" ]; then
+		echo "[e2e] FAIL create chapter for '${series_stub}': no comic row found." >&2
+		exit 1
+	fi
+
+	local data="comic_id=${comic_id}&name=${chapter_name// /+}&team%5B%5D=Anonymous&team%5B%5D=&volume=1&chapter=${chapter_number}&subchapter=0&language=it&hidden=0&description=&submit=Save"
+
+	curl -sS -o /dev/null \
+		-c "$COOKIE_JAR" -b "$COOKIE_JAR" \
+		-X POST \
+		-H 'Content-Type: application/x-www-form-urlencoded' \
+		--data "$data" \
+		"$BASE_URL/admin/series/add_new/${series_stub}"
+
+	local chapter_id
+	chapter_id="$(db_query "SELECT ch.id FROM fs_chapters ch JOIN fs_comics c ON c.id = ch.comic_id WHERE c.stub = '${series_stub}' AND ch.chapter = ${chapter_number} ORDER BY ch.id DESC LIMIT 1;")"
+	if [ -z "$chapter_id" ]; then
+		echo "[e2e] FAIL create chapter for '${series_stub}': no chapter row found." >&2
+		exit 1
+	fi
+
+	check_authed_page "/admin/series/series/${series_stub}/${chapter_id}/" 1000 "${chapter_name}" >&2
+
+	echo "$chapter_id"
+}
+
+upload_page_via_admin() {
+	local chapter_id="$1"
+	local response_file="$tmp_dir/upload_${chapter_id}.json"
+
+	curl -sS -o "$response_file" \
+		-c "$COOKIE_JAR" -b "$COOKIE_JAR" \
+		-F "chapter_id=${chapter_id}" \
+		-F "Filedata[]=@${ROOT_DIR}/scripts/page1.png;type=image/png" \
+		"$BASE_URL/admin/series/upload"
+
+	if ! grep -q '"name"' "$response_file"; then
+		echo "[e2e] FAIL upload for chapter ${chapter_id}: upload endpoint did not return file metadata." >&2
+		cat "$response_file" >&2
+		exit 1
+	fi
+}
+
 check_search_tags_multi() {
 	local tag_ids
 	tag_ids="$(docker compose exec -T db sh -lc "mysql -u foolslide_user -pfoobar -D foolslide_db -Nse \"SELECT id FROM fs_tags ORDER BY id LIMIT 2\"" 2>/dev/null | tr '\n' ' ' | xargs || true)"
@@ -366,6 +487,18 @@ else
 		else
 			echo "[e2e] SKIP /admin/series/add_new/<stub>: no existing series found in local DB."
 		fi
+
+		smoke_suffix="$(date +%s)"
+		no_tag_stub="$(create_series_via_admin "Smoke Series No Tag ${smoke_suffix}" 0)"
+		tagged_stub="$(create_series_via_admin "Smoke Series Tagged ${smoke_suffix}" 1)"
+		seeded_upload_chapter_id="$(db_query "SELECT ch.id FROM fs_chapters ch JOIN fs_comics c ON c.id = ch.comic_id WHERE c.stub = '${SEEDED_SERIES_STUB}' AND ch.uniqid = 'seedchapter002' LIMIT 1;")"
+		if [ -z "$seeded_upload_chapter_id" ]; then
+			echo "[e2e] FAIL upload smoke: no seeded chapter found." >&2
+			exit 1
+		fi
+		upload_page_via_admin "$seeded_upload_chapter_id"
+
+		check_authed_page "/admin/series/series/${tagged_stub}/" 1000 "Smoke Series Tagged ${smoke_suffix}"
 	fi
 fi
 


### PR DESCRIPTION
## Summary
- fix series creation so new records always get a valid slug and can be opened again from the admin list
- fix tagged series creation by replacing the fragile jointag persistence path with direct DB inserts
- fix chapter image uploads by pointing the UI to the real upload endpoint and replacing the broken page persistence path
- expand the e2e smoke script to cover series creation with and without tags plus a real authenticated page upload

## Why Smoke Missed It
- the previous smoke test only checked that the add-series and add-chapter pages rendered
- it did not submit the series creation form, verify the resulting admin series page, or post any upload request
- because of that, slug generation, jointag persistence, and upload persistence regressions were all outside the exercised path

## Verification
- `./scripts/run-tests.sh`
- `./scripts/run-e2e-smoke.sh`
