### PR TITLE
fix: support rich about page content

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 15;
+$config['migration_version'] = 16;
 
 
 /*

--- a/application/migrations/016_Update016.php
+++ b/application/migrations/016_Update016.php
@@ -1,0 +1,14 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Update016 extends CI_Migration {
+
+	function up() {
+		$this->db->query("
+				ALTER TABLE `" . $this->db->dbprefix('preferences') . "`
+					MODIFY `value` text COLLATE utf8_unicode_ci NOT NULL
+		");
+	}
+
+}

--- a/content/themes/dazen-skin/views/about.php
+++ b/content/themes/dazen-skin/views/about.php
@@ -30,7 +30,7 @@
 	<div class="group">
 		<div class="elemento">
 			<?php if (get_setting('fs_about_message')) : ?>
-				<p><?php echo get_setting('fs_about_message'); ?></p>
+				<?php echo get_setting('fs_about_message'); ?>
 			<?php else : ?>
 				<p>
 					<?php echo get_setting('fs_gen_site_title'); ?> <?php echo _('is a manga and comic reading platform dedicated to providing quality content to our community. Our mission is to make manga and comics easily accessible to everyone by maintaining an organized and user-friendly platform.'); ?>

--- a/content/themes/default/views/about.php
+++ b/content/themes/default/views/about.php
@@ -32,7 +32,7 @@
 	<div class="group">
 		<div class="elemento">
 			<?php if (get_setting('fs_about_message')) : ?>
-				<p><?php echo get_setting('fs_about_message'); ?></p>
+				<?php echo get_setting('fs_about_message'); ?>
 			<?php else : ?>
 				<p>
 					<?php echo get_setting('fs_gen_site_title'); ?> <?php echo _('is a manga and comic reading platform dedicated to providing quality content to our community. Our mission is to make manga and comics easily accessible to everyone by maintaining an organized and user-friendly platform.'); ?>


### PR DESCRIPTION
## Summary
- allow saved About content to render raw HTML instead of being wrapped in a forced paragraph
- add a migration to expand `fs_preferences.value` from `VARCHAR(2048)` to `TEXT`
- keep About-page styling configurable inside the saved HTML/CSS content itself

## Verify
- ./scripts/run-tests.sh
- ./scripts/run-e2e-smoke.sh

## Notes
- the formatted About-page HTML content is stored in preferences/admin data and is not part of this git diff
- the view change is required so custom block HTML and inline CSS from the About textbox render correctly