### PR TITLE
chore: require browser regression checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,9 @@
 
 ## Development Workflow
 - If the requested work is a fix or new feature and the current branch is a clean `main`, first create a feature branch before modifying files; do not wait for the user to ask.
+- For fixes and new features, use red/green TDD: add or update a failing automated test first, make the change, then rerun the tests to confirm they pass.
+- For fixes and new features, always run manual browser verification with `agent-browser` before finalizing. Official repo: https://github.com/vercel-labs/agent-browser
+- If a bug is discovered and fixed through browser automation/manual browser testing, add permanent automated coverage for that path as part of the same change.
 - Commit new features and fixes on feature branches only; do not commit directly to `main`.
 - Use the `gh` CLI to open pull requests targeting the `main` branch.
 - Always run all repository verification scripts in `scripts/` that are part of the normal workflow, especially `./scripts/run-tests.sh` and `./scripts/run-e2e-smoke.sh`, before finalizing.

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -446,13 +446,16 @@ create_series_via_admin() {
 
 create_team_via_admin() {
 	local team_name="$1"
-	local data="name=${team_name// /+}&stub=&url=&forum=&irc=&twitter=&facebook=&facebookid=&submit=Save"
-
 	curl -sS -o /dev/null \
 		-c "$COOKIE_JAR" -b "$COOKIE_JAR" \
-		-X POST \
-		-H 'Content-Type: application/x-www-form-urlencoded' \
-		--data "$data" \
+		-F "name=${team_name}" \
+		-F "url=" \
+		-F "forum=" \
+		-F "irc=" \
+		-F "twitter=" \
+		-F "facebook=" \
+		-F "facebookid=" \
+		-F "id=" \
 		"$BASE_URL/admin/members/add_team/"
 
 	local team_stub


### PR DESCRIPTION
## Summary
- require red/green TDD and manual `agent-browser` verification in `AGENTS.md`
- document that browser-found bugs must also get permanent automated test coverage, with a link to the official `agent-browser` repo
- extend smoke coverage for the browser-discovered team regressions (`multipart` team creation and `home_team` redirect)

## Verify
- `./scripts/run-tests.sh`
- `./scripts/run-e2e-smoke.sh`
