### PR TITLE
feat: add public teams page

### DIFF
--- a/application/controllers/reader.php
+++ b/application/controllers/reader.php
@@ -1044,6 +1044,7 @@ class Reader extends Public_Controller
 	{
 		$chapters = new Chapter();
 		$comics = new Comic();
+		$licenses = new License();
 		$db_table_prefix = $this->config_item('db_table_prefix');
 		if (!is_string($db_table_prefix))
 		{
@@ -1060,9 +1061,18 @@ class Reader extends Public_Controller
 		}
 		$chapters_table = $db_table_prefix . $chapters->table;
 		$comics_table = $db_table_prefix . $comics->table;
+		$licenses_table = $db_table_prefix . $licenses->table;
+		$license_filter = '';
+		if ((!isset($this->tank_auth) || (!$this->tank_auth->is_allowed() && !$this->tank_auth->is_team()))
+			&& isset($this->session)
+			&& ($nation = $this->session->userdata('nation')))
+		{
+			$escaped_nation = isset($this->db) ? $this->db->escape($nation) : "'" . addslashes($nation) . "'";
+			$license_filter = ' AND NOT EXISTS (SELECT 1 FROM ' . $licenses_table . ' l WHERE l.comic_id = c.id AND l.nation = ' . $escaped_nation . ')';
+		}
 		$teams = new Team();
 		$teams->where(
-			'id IN (SELECT DISTINCT ch.team_id FROM ' . $chapters_table . ' ch JOIN ' . $comics_table . ' c ON c.id = ch.comic_id WHERE ch.hidden = 0 AND ch.team_id != 0 AND c.hidden = 0)',
+			'id IN (SELECT DISTINCT ch.team_id FROM ' . $chapters_table . ' ch JOIN ' . $comics_table . ' c ON c.id = ch.comic_id WHERE ch.hidden = 0 AND ch.team_id != 0 AND c.hidden = 0' . $license_filter . ')',
 			NULL,
 			FALSE
 		);

--- a/application/controllers/reader.php
+++ b/application/controllers/reader.php
@@ -256,6 +256,13 @@ class Reader extends Public_Controller
 				'lastmod' => '',
 				'changefreq' => 'weekly',
 				'priority' => '0.5'
+			),
+			array(
+				// teams page
+				'loc' => site_url('teams'),
+				'lastmod' => '',
+				'changefreq' => 'weekly',
+				'priority' => '0.5'
 			)
 		);
 
@@ -529,6 +536,24 @@ class Reader extends Public_Controller
 		$this->template->set('param_stub', 'parody_stub');
 		$this->template->set('show_sidebar', TRUE);
 		$this->template->set('comics', $comics);
+		$this->template->build('menu');
+	}
+
+	public function teams($page = 1)
+	{
+		$teams = $this->get_published_teams();
+		$teams->order_by('name', 'ASC')->get_paged($page, 100);
+
+		$this->template->title(_('Teams'), get_setting('fs_gen_site_title'));
+		$this->template->set('title', _('Teams List'));
+		$this->template->set('link', 'teams');
+		$this->template->set('search_action', 'search_team/');
+		$this->template->set('items_name', 'teams');
+		$this->template->set('item_name_field', 'name');
+		$this->template->set('item_stub_field', 'stub');
+		$this->template->set('item_link_prefix', 'teamworks');
+		$this->template->set('show_sidebar', TRUE);
+		$this->template->set('items', $teams);
 		$this->template->build('menu');
 	}
 	
@@ -992,6 +1017,38 @@ class Reader extends Public_Controller
 		$this->template->set('param', 'parody');
 		$this->template->set('param_stub', 'parody_stub');
 		$this->template->build('menu');
+	}
+
+	public function search_team()
+	{
+		$search = $this->sanitize_search_query($this->input->post('search'));
+		$this->template->title(_('Search Team'));
+
+		$teams = $this->get_published_teams();
+		$teams->ilike('name', $search)->order_by('name', 'ASC')->get();
+
+		$this->template->set('title', _('Teams List'));
+		$this->template->set('show_sidebar', TRUE);
+		$this->template->set('search', $search);
+		$this->template->set('link', 'teams');
+		$this->template->set('search_action', 'search_team/');
+		$this->template->set('items_name', 'teams');
+		$this->template->set('item_name_field', 'name');
+		$this->template->set('item_stub_field', 'stub');
+		$this->template->set('item_link_prefix', 'teamworks');
+		$this->template->set('items', $teams);
+		$this->template->build('menu');
+	}
+
+	private function get_published_teams()
+	{
+		$chapters = new Chapter();
+		$db_table_prefix = $this->config_item('db_table_prefix');
+		$chapters_table = ($db_table_prefix ? $db_table_prefix : 'fs_') . $chapters->table;
+		$teams = new Team();
+		$teams->where('id IN (SELECT DISTINCT team_id FROM ' . $chapters_table . ' WHERE hidden = 0 AND team_id != 0)', NULL, FALSE);
+
+		return $teams;
 	}
 
 

--- a/application/controllers/reader.php
+++ b/application/controllers/reader.php
@@ -1043,6 +1043,7 @@ class Reader extends Public_Controller
 	private function get_published_teams()
 	{
 		$chapters = new Chapter();
+		$comics = new Comic();
 		$db_table_prefix = $this->config_item('db_table_prefix');
 		if (!is_string($db_table_prefix))
 		{
@@ -1058,8 +1059,13 @@ class Reader extends Public_Controller
 			}
 		}
 		$chapters_table = $db_table_prefix . $chapters->table;
+		$comics_table = $db_table_prefix . $comics->table;
 		$teams = new Team();
-		$teams->where('id IN (SELECT DISTINCT team_id FROM ' . $chapters_table . ' WHERE hidden = 0 AND team_id != 0)', NULL, FALSE);
+		$teams->where(
+			'id IN (SELECT DISTINCT ch.team_id FROM ' . $chapters_table . ' ch JOIN ' . $comics_table . ' c ON c.id = ch.comic_id WHERE ch.hidden = 0 AND ch.team_id != 0 AND c.hidden = 0)',
+			NULL,
+			FALSE
+		);
 
 		return $teams;
 	}

--- a/application/controllers/reader.php
+++ b/application/controllers/reader.php
@@ -1044,7 +1044,20 @@ class Reader extends Public_Controller
 	{
 		$chapters = new Chapter();
 		$db_table_prefix = $this->config_item('db_table_prefix');
-		$chapters_table = ($db_table_prefix ? $db_table_prefix : 'fs_') . $chapters->table;
+		if (!is_string($db_table_prefix))
+		{
+			$db_table_prefix = '';
+			if (file_exists(FCPATH . 'config.php'))
+			{
+				$db = array();
+				require(FCPATH . 'config.php');
+				if (isset($db['default']['dbprefix']) && is_string($db['default']['dbprefix']))
+				{
+					$db_table_prefix = $db['default']['dbprefix'];
+				}
+			}
+		}
+		$chapters_table = $db_table_prefix . $chapters->table;
 		$teams = new Team();
 		$teams->where('id IN (SELECT DISTINCT team_id FROM ' . $chapters_table . ' WHERE hidden = 0 AND team_id != 0)', NULL, FALSE);
 

--- a/content/themes/dazen-skin/views/layouts/reader.php
+++ b/content/themes/dazen-skin/views/layouts/reader.php
@@ -86,6 +86,7 @@
 						<li><a href="<?php echo site_url('tags') ?>"><span class="mh"><?php echo _('Tags'); ?></span></a></li>
 						<li><a href="<?php echo site_url('authors') ?>"><span class="mh"> <?php echo _('Authors'); ?></span></a></li>
 						<li><a href="<?php echo site_url('parodies') ?>"><span class="mh"> <?php echo _('Parodies'); ?></span></a></li>
+						<li><a href="<?php echo site_url('teams') ?>"><span class="mh"> <?php echo _('Teams'); ?></span></a></li>
 							<li><a href="<?php echo site_url('most_downloaded') ?>"><span class="mh"> <?php echo _('Most Downloaded'); ?></span></a></li>
 							<?php if (has_about_page()) : ?>
 								<li><a href="<?php echo site_url('about') ?>"><span class="mh"> <?php echo about_label('About'); ?></span></a></li>

--- a/content/themes/dazen-skin/views/menu.php
+++ b/content/themes/dazen-skin/views/menu.php
@@ -8,17 +8,24 @@ if (! defined ( 'BASEPATH' ))
 		<a href="<?php echo site_url($link) ?>"><?php echo $title; ?></a>
 	</div>
 	<?php
-	echo form_open("search_".$param."/");
+	$items_name = isset($items_name) ? $items_name : 'comics';
+	$items = isset($items) ? $items : $$items_name;
+	$item_name_field = isset($item_name_field) ? $item_name_field : $param;
+	$item_stub_field = isset($item_stub_field) ? $item_stub_field : $param_stub;
+	$item_link_prefix = isset($item_link_prefix) ? $item_link_prefix : $param;
+	$search_action = isset($search_action) ? $search_action : "search_".$param."/";
+
+	echo form_open($search_action);
 	echo form_input(array('name' => 'search', 'placeholder' => _('To search, type and hit enter'), 'id' => 'menusearchbox', 'class' => 'menu'));
 	echo form_close();
 
 	$old = '';
-	foreach ( $comics as $key => $comic ) {
-		$current = $comic->$param_stub;
+	foreach ( $items as $key => $item ) {
+		$current = $item->$item_stub_field;
 		if ($current !== $old)
-			echo '<a class="attribute-row" href="' . base_url () . $param . '/'. $comic->$param_stub .'">' . $comic->$param . '</a>';
+			echo '<a class="attribute-row" href="' . base_url () . $item_link_prefix . '/'. $item->$item_stub_field .'">' . $item->$item_name_field . '</a>';
 		$old = $current;
 	}
-	echo prevnext($link.'/', $comics);
+	echo prevnext($link.'/', $items);
 	?>
 </div>

--- a/content/themes/default/views/layouts/reader.php
+++ b/content/themes/default/views/layouts/reader.php
@@ -81,6 +81,7 @@
 						<li><a href="<?php echo site_url('most_downloaded') ?>"><i class="fa fa-download"></i><span class="mh"> <?php echo _('Most Downloaded'); ?></span></a></li>						
 						<li><a href="<?php echo site_url('authors') ?>"><i class="fa fa-users"></i><span class="mh"> <?php echo _('Authors'); ?></span></a></li>						
 						<li><a href="<?php echo site_url('parodies') ?>"><i class="fa fa-film"></i><span class="mh"> <?php echo _('Parodies'); ?></span></a></li>						
+						<li><a href="<?php echo site_url('teams') ?>"><i class="fa fa-users"></i><span class="mh"> <?php echo _('Teams'); ?></span></a></li>
 						<?php if (has_about_page()) : ?>
 							<li><a href="<?php echo site_url('about') ?>"><i class="fa fa-info-circle"></i><span class="mh"> <?php echo about_label('About'); ?></span></a></li>
 						<?php endif; ?>						

--- a/content/themes/default/views/menu.php
+++ b/content/themes/default/views/menu.php
@@ -8,17 +8,24 @@ if (! defined ( 'BASEPATH' ))
 		<a href="<?php echo site_url($link) ?>"><?php echo $title; ?></a>
 	</div>
 	<?php 
-	echo form_open("search_".$param."/");
+	$items_name = isset($items_name) ? $items_name : 'comics';
+	$items = isset($items) ? $items : $$items_name;
+	$item_name_field = isset($item_name_field) ? $item_name_field : $param;
+	$item_stub_field = isset($item_stub_field) ? $item_stub_field : $param_stub;
+	$item_link_prefix = isset($item_link_prefix) ? $item_link_prefix : $param;
+	$search_action = isset($search_action) ? $search_action : "search_".$param."/";
+
+	echo form_open($search_action);
 	echo form_input(array('name' => 'search', 'placeholder' => _('To search, type and hit enter'), 'id' => 'menusearchbox', 'class' => 'menu'));
 	echo form_close();
 
 	$old = '';
-	foreach ( $comics as $key => $comic ) {
-		$current = $comic->$param_stub;
+	foreach ( $items as $key => $item ) {
+		$current = $item->$item_stub_field;
 		if ($current !== $old)
-			echo '<a class="attribute-row" href="' . base_url () . $param . '/'. $comic->$param_stub .'">' . $comic->$param . '</a>';
+			echo '<a class="attribute-row" href="' . base_url () . $item_link_prefix . '/'. $item->$item_stub_field .'">' . $item->$item_name_field . '</a>';
 		$old = $current;
 	}
-	echo prevnext($link.'/', $comics);
+	echo prevnext($link.'/', $items);
 	?>
 </div>

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -624,6 +624,7 @@ else
 	fi
 	check_page "/latest/" 1000 "<!DOCTYPE html"
 	check_page "/tags/" 1000 "${SEEDED_PRIMARY_TAG_NAME}"
+	check_page "/teams/" 800 "Teams List"
 	check_post_page "/series/${SEEDED_SERIES_STUB}/" "adult=true" 1000 "${series_marker}"
 	check_page "/about/" 1000 'name="contact_name"'
 	check_post_page "/about/" "contact_name=&contact_email=&contact_subject=&contact_message=&contact_website=" 1000 'contact_name'

--- a/tests/controllers/ReaderControllerTest.php
+++ b/tests/controllers/ReaderControllerTest.php
@@ -341,6 +341,21 @@ class ReaderControllerTest extends TestCase
 		$this->assertSame(array('id IN (SELECT DISTINCT ch.team_id FROM chapters ch JOIN comics c ON c.id = ch.comic_id WHERE ch.hidden = 0 AND ch.team_id != 0 AND c.hidden = 0)', null, false), Team::$whereArgs[0]);
 	}
 
+	public function testTeamsExcludeNationLicensedComicsForPublicReaders()
+	{
+		$controller = $this->newController();
+		$controller->template = new StubTemplate();
+		$controller->session = new StubSession();
+		$controller->session->set_userdata('nation', 'IT');
+		$controller->tank_auth = new StubTankAuth(false, false);
+		$controller->db = new StubDb();
+		Team::reset();
+
+		$controller->teams();
+
+		$this->assertSame(array("id IN (SELECT DISTINCT ch.team_id FROM fs_chapters ch JOIN fs_comics c ON c.id = ch.comic_id WHERE ch.hidden = 0 AND ch.team_id != 0 AND c.hidden = 0 AND NOT EXISTS (SELECT 1 FROM fs_licenses l WHERE l.comic_id = c.id AND l.nation = 'IT'))", null, false), Team::$whereArgs[0]);
+	}
+
 	public function testRemapCallsReaderMethodWhenAvailable()
 	{
 		$controller = new ReaderPingController();
@@ -600,6 +615,14 @@ class StubConfig
 	}
 }
 
+class StubDb
+{
+	public function escape($value)
+	{
+		return "'" . str_replace("'", "\\'", $value) . "'";
+	}
+}
+
 class StubAgent
 {
 	private $robot;
@@ -612,6 +635,28 @@ class StubAgent
 	public function is_robot()
 	{
 		return $this->robot;
+	}
+}
+
+class StubTankAuth
+{
+	private $allowed;
+	private $team;
+
+	public function __construct($allowed, $team)
+	{
+		$this->allowed = $allowed;
+		$this->team = $team;
+	}
+
+	public function is_allowed()
+	{
+		return $this->allowed;
+	}
+
+	public function is_team()
+	{
+		return $this->team;
 	}
 }
 
@@ -794,6 +839,14 @@ if (!class_exists('Comic'))
 	}
 }
 
+if (!class_exists('License'))
+{
+	class License
+	{
+		public $table = 'licenses';
+	}
+}
+
 if (!class_exists('Jointag'))
 {
 	class Jointag implements IteratorAggregate
@@ -918,6 +971,8 @@ class ReaderTestController extends Reader
 	public $form_validation;
 	public $email;
 	public $config;
+	public $tank_auth;
+	public $db;
 
 	public function __construct()
 	{

--- a/tests/controllers/ReaderControllerTest.php
+++ b/tests/controllers/ReaderControllerTest.php
@@ -306,7 +306,7 @@ class ReaderControllerTest extends TestCase
 		$this->assertSame('name', $template->values['item_name_field']);
 		$this->assertSame('stub', $template->values['item_stub_field']);
 		$this->assertSame('teams', $template->values['items_name']);
-		$this->assertSame(array('id IN (SELECT DISTINCT team_id FROM fs_chapters WHERE hidden = 0 AND team_id != 0)', null, false), Team::$whereArgs[0]);
+		$this->assertSame(array('id IN (SELECT DISTINCT ch.team_id FROM fs_chapters ch JOIN fs_comics c ON c.id = ch.comic_id WHERE ch.hidden = 0 AND ch.team_id != 0 AND c.hidden = 0)', null, false), Team::$whereArgs[0]);
 	}
 
 	public function testSearchTeamBuildsMenuViewUsingPublishedTeamsOnly()
@@ -326,7 +326,7 @@ class ReaderControllerTest extends TestCase
 		$this->assertSame('search_team/', $template->values['search_action']);
 		$this->assertSame('teamworks', $template->values['item_link_prefix']);
 		$this->assertSame(array('name', 'scan'), Team::$ilikeArgs);
-		$this->assertSame(array('id IN (SELECT DISTINCT team_id FROM fs_chapters WHERE hidden = 0 AND team_id != 0)', null, false), Team::$whereArgs[0]);
+		$this->assertSame(array('id IN (SELECT DISTINCT ch.team_id FROM fs_chapters ch JOIN fs_comics c ON c.id = ch.comic_id WHERE ch.hidden = 0 AND ch.team_id != 0 AND c.hidden = 0)', null, false), Team::$whereArgs[0]);
 	}
 
 	public function testTeamsHonorsExplicitEmptyDbPrefix()
@@ -338,7 +338,7 @@ class ReaderControllerTest extends TestCase
 
 		$controller->teams();
 
-		$this->assertSame(array('id IN (SELECT DISTINCT team_id FROM chapters WHERE hidden = 0 AND team_id != 0)', null, false), Team::$whereArgs[0]);
+		$this->assertSame(array('id IN (SELECT DISTINCT ch.team_id FROM chapters ch JOIN comics c ON c.id = ch.comic_id WHERE ch.hidden = 0 AND ch.team_id != 0 AND c.hidden = 0)', null, false), Team::$whereArgs[0]);
 	}
 
 	public function testRemapCallsReaderMethodWhenAvailable()
@@ -720,6 +720,7 @@ if (!class_exists('Comic'))
 	class Comic
 	{
 		public static $throwOnIlike = false;
+		public $table = 'comics';
 		public $id = 7;
 		public $typeh_id = 1;
 		public $creator = 1;

--- a/tests/controllers/ReaderControllerTest.php
+++ b/tests/controllers/ReaderControllerTest.php
@@ -329,6 +329,18 @@ class ReaderControllerTest extends TestCase
 		$this->assertSame(array('id IN (SELECT DISTINCT team_id FROM fs_chapters WHERE hidden = 0 AND team_id != 0)', null, false), Team::$whereArgs[0]);
 	}
 
+	public function testTeamsHonorsExplicitEmptyDbPrefix()
+	{
+		$controller = $this->newController();
+		$controller->template = new StubTemplate();
+		$controller->config = new StubConfig(array('db_table_prefix' => ''));
+		Team::reset();
+
+		$controller->teams();
+
+		$this->assertSame(array('id IN (SELECT DISTINCT team_id FROM chapters WHERE hidden = 0 AND team_id != 0)', null, false), Team::$whereArgs[0]);
+	}
+
 	public function testRemapCallsReaderMethodWhenAvailable()
 	{
 		$controller = new ReaderPingController();

--- a/tests/controllers/ReaderControllerTest.php
+++ b/tests/controllers/ReaderControllerTest.php
@@ -289,6 +289,46 @@ class ReaderControllerTest extends TestCase
 		$this->assertIsArray($template->values['comics']);
 	}
 
+	public function testTeamsBuildsMenuViewUsingPublishedTeamsOnly()
+	{
+		$controller = $this->newController();
+		$template = new StubTemplate();
+		$controller->template = $template;
+		Team::reset();
+
+		$controller->teams();
+
+		$this->assertSame('menu', $template->builtView);
+		$this->assertSame('Teams List', $template->values['title']);
+		$this->assertSame('teams', $template->values['link']);
+		$this->assertSame('search_team/', $template->values['search_action']);
+		$this->assertSame('teamworks', $template->values['item_link_prefix']);
+		$this->assertSame('name', $template->values['item_name_field']);
+		$this->assertSame('stub', $template->values['item_stub_field']);
+		$this->assertSame('teams', $template->values['items_name']);
+		$this->assertSame(array('id IN (SELECT DISTINCT team_id FROM fs_chapters WHERE hidden = 0 AND team_id != 0)', null, false), Team::$whereArgs[0]);
+	}
+
+	public function testSearchTeamBuildsMenuViewUsingPublishedTeamsOnly()
+	{
+		$controller = $this->newController();
+		$template = new StubTemplate();
+		$controller->template = $template;
+		$controller->input = new StubInput(array('search' => 'scan'));
+		Team::reset();
+
+		$controller->search_team();
+
+		$this->assertSame('menu', $template->builtView);
+		$this->assertSame('scan', $template->values['search']);
+		$this->assertSame('Teams List', $template->values['title']);
+		$this->assertSame('teams', $template->values['link']);
+		$this->assertSame('search_team/', $template->values['search_action']);
+		$this->assertSame('teamworks', $template->values['item_link_prefix']);
+		$this->assertSame(array('name', 'scan'), Team::$ilikeArgs);
+		$this->assertSame(array('id IN (SELECT DISTINCT team_id FROM fs_chapters WHERE hidden = 0 AND team_id != 0)', null, false), Team::$whereArgs[0]);
+	}
+
 	public function testRemapCallsReaderMethodWhenAvailable()
 	{
 		$controller = new ReaderPingController();
@@ -618,6 +658,51 @@ if (!class_exists('Tag'))
 	}
 }
 
+if (!class_exists('Team'))
+{
+	class Team
+	{
+		public static $ilikeArgs = null;
+		public static $whereArgs = array();
+		public $all = array();
+
+		public static function reset()
+		{
+			self::$ilikeArgs = null;
+			self::$whereArgs = array();
+		}
+
+		public function order_by($field, $direction)
+		{
+			return $this;
+		}
+
+		public function ilike($field, $value)
+		{
+			self::$ilikeArgs = array($field, $value);
+			return $this;
+		}
+
+		public function where($field, $value = null, $escape = true)
+		{
+			self::$whereArgs[] = array($field, $value, $escape);
+			return $this;
+		}
+
+		public function get_paged($page = 1, $page_size = 50)
+		{
+			$this->all = array((object) array('name' => 'Demo Team', 'stub' => 'demo-team'));
+			return $this;
+		}
+
+		public function get()
+		{
+			$this->all = array((object) array('name' => 'Demo Team', 'stub' => 'demo-team'));
+			return $this;
+		}
+	}
+}
+
 if (!class_exists('Comic'))
 {
 	class Comic
@@ -739,6 +824,9 @@ if (!class_exists('Chapter'))
 {
 	class Chapter
 	{
+		public $table = 'chapters';
+		public $all = array();
+
 		public function where($key, $value)
 		{
 			return $this;
@@ -756,6 +844,7 @@ if (!class_exists('Chapter'))
 
 		public function get()
 		{
+			$this->all = array((object) array('team_id' => 5));
 			return $this;
 		}
 


### PR DESCRIPTION
## Summary
- add a public  reader page and search action using the same themed menu layout as authors/parodies
- show only teams with public chapter publications and link each item to the existing  page
- add the Teams nav item to both bundled reader themes and cover the route in unit and smoke tests

## Verification
- [tests] Host php is unavailable, skipping vendor/bin/phpunit and falling back to Docker
[tests] Running phpunit in Docker (service: web)
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.19
Configuration: phpunit.xml

...................................                               35 / 35 (100%)

Time: 00:00.003, Memory: 6.00 MB

OK (35 tests, 95 assertions)
[tests] Running e2e smoke suite
[e2e] Starting Docker Compose stack
#1 [internal] load local bake definitions
#1 reading from stdin 554B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 886B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/php:8.4-apache
#3 DONE 0.6s

#4 [internal] load .dockerignore
#4 transferring context: 2B done
#4 DONE 0.0s

#5 [ 1/15] FROM docker.io/library/php:8.4-apache@sha256:1e4d8ddf81c7c55b3306e852ec3cc5a8f0e5ceeb4897efeab2a87de17016786b
#5 resolve docker.io/library/php:8.4-apache@sha256:1e4d8ddf81c7c55b3306e852ec3cc5a8f0e5ceeb4897efeab2a87de17016786b done
#5 DONE 0.0s

#6 [internal] load build context
#6 transferring context: 514.30kB 0.1s done
#6 DONE 0.1s

#7 [ 6/15] COPY apache-vhost.conf /etc/apache2/sites-available/000-default.conf
#7 CACHED

#8 [ 4/15] RUN echo "date.timezone = UTC" > /usr/local/etc/php/conf.d/timezone.ini
#8 CACHED

#9 [ 2/15] RUN apt-get update && apt-get install -y --no-install-recommends     libfreetype6-dev     libjpeg62-turbo-dev     libpng-dev     libzip-dev     libxml2-dev     && rm -rf /var/lib/apt/lists/*
#9 CACHED

#10 [ 3/15] RUN docker-php-ext-configure gd --with-freetype --with-jpeg     && docker-php-ext-install -j$(nproc) gd mysqli zip xml
#10 CACHED

#11 [ 5/15] RUN a2enmod rewrite
#11 CACHED

#12 [ 7/15] WORKDIR /var/www/html
#12 CACHED

#13 [ 8/15] COPY . /var/www/html/
#13 DONE 0.3s

#14 [ 9/15] COPY .htaccess /var/www/html/.htaccess
#14 DONE 0.0s

#15 [10/15] RUN mkdir -p /var/www/html/content/logs
#15 DONE 0.1s

#16 [11/15] RUN mkdir -p /var/www/html/content/cache
#16 DONE 0.2s

#17 [12/15] RUN mkdir -p /var/www/html/content/comics
#17 DONE 0.2s

#18 [13/15] RUN mkdir -p /var/www/html/content/tags
#18 DONE 0.2s

#19 [14/15] RUN chown -R www-data:www-data /var/www/html
#19 DONE 0.3s

#20 [15/15] RUN chmod -R 777 /var/www/html
#20 DONE 0.3s

#21 exporting to image
#21 exporting layers
#21 exporting layers 0.7s done
#21 writing image sha256:05419ea9337f7d080830600b6a3598ada531c43b30c684aca72776fd20a31eb3 done
#21 naming to docker.io/library/foolslide-improved-web done
#21 DONE 0.7s

#22 resolving provenance for metadata file
#22 DONE 0.0s
[e2e] Waiting for http://localhost:8080 to become reachable
[e2e] / -> status=200 bytes=7572
[e2e] Seeding Docker dev state
[seed] Ensured Docker dev seed data: admin/admin, again-my-childhood-friend
[e2e] /latest/ -> status=200 bytes=7572
[e2e] /tags/ -> status=200 bytes=7889
[e2e] /teams/ -> status=200 bytes=4883
[e2e] POST /series/again-my-childhood-friend/ -> status=200 bytes=8804
[e2e] /about/ -> status=200 bytes=11076
[e2e] POST /about/ -> status=200 bytes=11843
[e2e] /account/auth/login/ -> status=200 bytes=5358
[e2e] /admin/ -> status=200 bytes=5358
[e2e] /install -> status=200 bytes=5358
[e2e] POST /search/ -> status=200 bytes=4549
[e2e] POST /search_tags/ -> status=200 bytes=7889
[e2e] POST /search_tags/ -> status=200 bytes=8108
[e2e] /read/again-my-childhood-friend/it/1/2/page/1 -> status=200 bytes=5025
[e2e] DOWNLOAD /download/again-my-childhood-friend/seedchapter002/it/1/2/ -> status=200 bytes=2013325
[e2e] /download/again-my-childhood-friend/seedchapter002/it/1/2/ headers_bytes=1709
[e2e] /read/again-my-childhood-friend/it/1/2/page/1 -> status=200 bytes=5025
[e2e] POST /account/auth/login/ -> status=200
[e2e] /account/auth/login/ headers_bytes=2307
[e2e] AUTH /admin/series/add_new/ -> status=200 bytes=36929
[e2e] /admin/series/add_new/ headers_bytes=205
[e2e] AUTH /admin/series/series/again-my-childhood-friend/ -> status=200 bytes=44639
[e2e] /admin/series/series/again-my-childhood-friend/ headers_bytes=205
[e2e] AUTH /admin/series/add_new/again-my-childhood-friend -> status=200 bytes=20728
[e2e] /admin/series/add_new/again-my-childhood-friend headers_bytes=205
[e2e] AUTH /admin/members/teams/ -> status=200 bytes=18740
[e2e] /admin/members/teams/ headers_bytes=205
[e2e] AUTH GET /admin/members/home_team/ -> status=302 location=http://localhost:8080/admin/members/teams/anonymous2/
[e2e] AUTH /admin/members/teams/anonymous2 -> status=200 bytes=15987
[e2e] /admin/members/teams/anonymous2 headers_bytes=205
[e2e] /team/anonymous2 -> status=200 bytes=843
[e2e] AUTH /admin/series/series/smoke-series-tagged-1773687552/ -> status=200 bytes=40269
[e2e] /admin/series/series/smoke-series-tagged-1773687552/ headers_bytes=205
[e2e] PASS: smoke routes are serving HTML pages correctly.
- manual browser smoke check for the new Teams nav item, list page, and click-through to 