### PR TITLE
fix: clean up team page metadata and home team nav

### DIFF
--- a/application/controllers/admin/members.php
+++ b/application/controllers/admin/members.php
@@ -333,7 +333,7 @@ class Members extends Admin_Controller
 			redirect('/admin/members/teams/');
 		}
 
-		redirect('/admin/members/teams/' . $team->stub);
+		return $this->teams($team->stub);
 	}
 
 

--- a/content/themes/dazen-skin/views/team.php
+++ b/content/themes/dazen-skin/views/team.php
@@ -12,17 +12,22 @@ if (!defined('BASEPATH'))
 	echo '<div class="group">
 					<div class="title">' . _('Informations') . '</span></div>
 				';
+	if (trim((string) $team->url) !== '')
+		echo '<div class="element">
+					<div class="title">' . _("URL") . ': <a href="' . $team->url . '">' . $team->url . '</a></div></div>';
 	echo '<div class="element">
-					<div class="title">' . _("URL") . ': <a href="' . $team->url . '">' . $team->url . '</a></div></div>
-						<div class="element">
-					<div class="title">' . _("Translations") . ': <a href="' . site_url() . 'teamworks/' . $team->stub . '">' . site_url() . 'teamworks/' . $team->stub . '</a></div></div>
-						<div class="element">
-					<div class="title">' . _("IRC") . ': <a href="' . parse_irc($team->irc) . '">' . $team->irc . '</a></div></div>
-						<div class="element">
-					<div class="title">' . _("X") . ': <a href="https://x.com/' . $team->twitter . '">https://x.com/' . $team->twitter . '</a></div></div>
-						<div class="element">
+					<div class="title">' . _("Translations") . ': <a href="' . site_url() . 'teamworks/' . $team->stub . '">' . site_url() . 'teamworks/' . $team->stub . '</a></div></div>';
+	if (trim((string) $team->irc) !== '')
+		echo '<div class="element">
+					<div class="title">' . _("IRC") . ': <a href="' . parse_irc($team->irc) . '">' . $team->irc . '</a></div></div>';
+	if (trim((string) $team->twitter) !== '')
+		echo '<div class="element">
+					<div class="title">' . _("X") . ': <a href="https://x.com/' . $team->twitter . '">https://x.com/' . $team->twitter . '</a></div></div>';
+	if (trim((string) $team->facebook) !== '')
+		echo '<div class="element">
 					<div class="title">' . _("Facebook") . ': <a href="' . $team->facebook . '">' . $team->facebook . '</a></div>
-				</div></div>';
+				</div>';
+	echo '</div>';
 
 
 	echo '<div class="group">

--- a/content/themes/default/views/team.php
+++ b/content/themes/default/views/team.php
@@ -12,17 +12,22 @@ if (!defined('BASEPATH'))
 	echo '<div class="group">
 					<div class="title">' . _('Informations') . '</span></div>
 				';
+	if (trim((string) $team->url) !== '')
+		echo '<div class="element">
+					<div class="title">' . _("URL") . ': <a href="' . $team->url . '">' . $team->url . '</a></div></div>';
 	echo '<div class="element">
-					<div class="title">' . _("URL") . ': <a href="' . $team->url . '">' . $team->url . '</a></div></div>
-						<div class="element">
-					<div class="title">' . _("Translations") . ': <a href="' . site_url() . 'teamworks/' . $team->stub . '">' . site_url() . 'teamworks/' . $team->stub . '</a></div></div>
-						<div class="element">
-					<div class="title">' . _("IRC") . ': <a href="' . parse_irc($team->irc) . '">' . $team->irc . '</a></div></div>
-						<div class="element">
-					<div class="title">' . _("X") . ': <a href="https://x.com/' . $team->twitter . '">https://x.com/' . $team->twitter . '</a></div></div>
-						<div class="element">
+					<div class="title">' . _("Translations") . ': <a href="' . site_url() . 'teamworks/' . $team->stub . '">' . site_url() . 'teamworks/' . $team->stub . '</a></div></div>';
+	if (trim((string) $team->irc) !== '')
+		echo '<div class="element">
+					<div class="title">' . _("IRC") . ': <a href="' . parse_irc($team->irc) . '">' . $team->irc . '</a></div></div>';
+	if (trim((string) $team->twitter) !== '')
+		echo '<div class="element">
+					<div class="title">' . _("X") . ': <a href="https://x.com/' . $team->twitter . '">https://x.com/' . $team->twitter . '</a></div></div>';
+	if (trim((string) $team->facebook) !== '')
+		echo '<div class="element">
 					<div class="title">' . _("Facebook") . ': <a href="' . $team->facebook . '">' . $team->facebook . '</a></div>
-				</div></div>';
+				</div>';
+	echo '</div>';
 
 
 	echo '<div class="group">

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -475,7 +475,7 @@ create_team_via_admin() {
 	fi
 
 	check_authed_page "/admin/members/teams/${team_stub}" 1000 "${team_name}" >&2
-	check_page_fragment "/team/${team_stub}" 600 "${team_name}" >&2
+	check_page_fragment "/team/${team_stub}" 400 "${team_name}" >&2
 	check_page "/teamworks/${team_stub}" 800 "<!DOCTYPE html" >&2
 
 	echo "$team_stub"
@@ -510,7 +510,7 @@ add_team_leader_via_admin() {
 	fi
 
 	check_authed_page "/admin/members/teams/${team_stub}" 1000 "${username}" >&2
-	check_page_fragment "/team/${team_stub}" 600 "teamworks/${team_stub}" >&2
+	check_page_fragment "/team/${team_stub}" 400 "teamworks/${team_stub}" >&2
 }
 
 create_chapter_via_admin() {
@@ -652,9 +652,9 @@ else
 		check_authed_page "/admin/members/teams/" 1000 "<!DOCTYPE html"
 		seeded_team_stub="$(db_query "SELECT stub FROM fs_teams ORDER BY id LIMIT 1;")"
 		if [ -n "$seeded_team_stub" ]; then
-			check_authed_redirect "/admin/members/home_team/" "/admin/members/teams/${seeded_team_stub}"
+			check_authed_page "/admin/members/home_team/" 1000 "<!DOCTYPE html"
 			check_authed_page "/admin/members/teams/${seeded_team_stub}" 1000 "<!DOCTYPE html"
-			check_page_fragment "/team/${seeded_team_stub}" 600 "teamworks/${seeded_team_stub}"
+			check_page_fragment "/team/${seeded_team_stub}" 400 "teamworks/${seeded_team_stub}"
 		fi
 		team_stub="$(create_team_via_admin "Smoke Team ${smoke_suffix}")"
 		add_team_leader_via_admin "$team_stub" "$ADMIN_USER"


### PR DESCRIPTION
## Summary
- hide empty team metadata rows on public team pages for URL, IRC, X, and Facebook
- keep `/admin/members/home_team/` on the home-team route so the admin Members dropdown highlights `Home Team`
- update the e2e smoke suite for the home-team route and the smaller team page response size

## Verification
- `./scripts/run-tests.sh --with-e2e`
- manual browser checks for a blank-metadata `/team/<stub>` page and the active `Home Team` admin menu state