### PR TITLE
fix: restore public team member layout

### DIFF
--- a/content/themes/dazen-skin/style.css
+++ b/content/themes/dazen-skin/style.css
@@ -385,6 +385,26 @@ input[class="menu"]{
 	position: relative;
 	z-index: 100;
 }
+.list .element.team-member{
+	display: block;
+	overflow: hidden;
+}
+.list .element.team-member .image img{
+	display: block;
+	height: 75px;
+	width: 75px;
+}
+.list .element.team-member .member-details{
+	overflow: hidden;
+}
+.list .element.team-member .member-details .title{
+	float: none;
+}
+.list .element.team-member .member-meta{
+	color: #c8cdd8;
+	line-height: 1.4;
+	margin-top: 4px;
+}
 .large{
 	background: #f7f7f7;
 	background-image: url(images/background_noise_light.png);

--- a/content/themes/dazen-skin/views/team.php
+++ b/content/themes/dazen-skin/views/team.php
@@ -42,11 +42,16 @@ if (!defined('BASEPATH'))
 		foreach ($members as $key => $member) {
 			if (!$member->is_leader)
 				continue;
-			echo '<div class="element">
-					<div class="image">'.get_gravatar($member->email, 75, NULL, NULL, TRUE).'</div>
-					<div class="info"><b>' . (HTMLpurify(($member->profile_display_name)?$member->profile_display_name:$member->username, 'unallowed')) . '</b></div>';
-					if($member->profile_bio) echo '<div class="info">'._('Bio').': '.(HTMLpurify($member->profile_bio, 'unallowed')).'</div>';
-					if($member->profile_twitter) echo '<div class="info">'._('X').': <a href="https://x.com/'.(HTMLpurify($member->profile_twitter, 'unallowed')).'" target="_blank">'.(HTMLpurify($member->profile_twitter, 'unallowed')).'</a></div>';
+			$member_name = htmlspecialchars(($member->profile_display_name) ? $member->profile_display_name : $member->username, ENT_QUOTES, 'UTF-8');
+			$member_bio = htmlspecialchars((string) $member->profile_bio, ENT_QUOTES, 'UTF-8');
+			$member_twitter = htmlspecialchars((string) $member->profile_twitter, ENT_QUOTES, 'UTF-8');
+			echo '<div class="element team-member">
+					<div class="image">'.get_gravatar($member->email, 75, NULL, NULL, TRUE, array('width' => '75', 'height' => '75', 'style' => 'width:75px;height:75px;')).'</div>
+					<div class="member-details">
+						<div class="title">' . $member_name . '</div>';
+					if($member->profile_bio) echo '<div class="member-meta">'._('Bio').': '.$member_bio.'</div>';
+					if($member->profile_twitter) echo '<div class="member-meta">'._('X').': <a href="https://x.com/'.$member_twitter.'" target="_blank">'.$member_twitter.'</a></div>';
+					echo '</div>';
 				echo '</div>';
 		}
 
@@ -62,11 +67,16 @@ if (!defined('BASEPATH'))
 		foreach ($members as $key => $member) {
 			if ($member->is_leader)
 				continue;
-			echo '<div class="element">
-					<div class="image">'.get_gravatar($member->email, 75, NULL, NULL, TRUE).'</div>
-					<div class="info"><b>' . (HTMLpurify(($member->profile_display_name)?$member->profile_display_name:$member->username, 'unallowed')) . '</b></div>';
-					if($member->profile_bio) echo '<div class="info">'._('Bio').': '.(HTMLpurify($member->profile_bio, 'unallowed')).'</div>';
-					if($member->profile_twitter) echo '<div class="info">'._('X').': <a href="https://x.com/'.(HTMLpurify($member->profile_twitter, 'unallowed')).'" target="_blank">'.(HTMLpurify($member->profile_twitter, 'unallowed')).'</a></div>';
+			$member_name = htmlspecialchars(($member->profile_display_name) ? $member->profile_display_name : $member->username, ENT_QUOTES, 'UTF-8');
+			$member_bio = htmlspecialchars((string) $member->profile_bio, ENT_QUOTES, 'UTF-8');
+			$member_twitter = htmlspecialchars((string) $member->profile_twitter, ENT_QUOTES, 'UTF-8');
+			echo '<div class="element team-member">
+					<div class="image">'.get_gravatar($member->email, 75, NULL, NULL, TRUE, array('width' => '75', 'height' => '75', 'style' => 'width:75px;height:75px;')).'</div>
+					<div class="member-details">
+						<div class="title">' . $member_name . '</div>';
+					if($member->profile_bio) echo '<div class="member-meta">'._('Bio').': '.$member_bio.'</div>';
+					if($member->profile_twitter) echo '<div class="member-meta">'._('X').': <a href="https://x.com/'.$member_twitter.'" target="_blank">'.$member_twitter.'</a></div>';
+					echo '</div>';
 				echo '</div>';
 		}
 	echo '</div>'

--- a/content/themes/default/style.css
+++ b/content/themes/default/style.css
@@ -382,6 +382,24 @@ input[class="menu"]{
 	position: relative;
 	z-index: 100;
 }
+.list .element.team-member{
+	overflow: hidden;
+}
+.list .element.team-member .image img{
+	display: block;
+	height: 75px;
+	width: 75px;
+}
+.list .element.team-member .member-details{
+	overflow: hidden;
+}
+.list .element.team-member .member-details .title{
+	float: none;
+}
+.list .element.team-member .member-meta{
+	line-height: 1.4;
+	margin-top: 4px;
+}
 .large{
 	background: #f7f7f7;
 	background-image: url(images/background_noise_light.png);

--- a/content/themes/default/views/team.php
+++ b/content/themes/default/views/team.php
@@ -42,11 +42,16 @@ if (!defined('BASEPATH'))
 		foreach ($members as $key => $member) {
 			if (!$member->is_leader)
 				continue;
-			echo '<div class="element">
-					<div class="image">'.get_gravatar($member->email, 75, NULL, NULL, TRUE).'</div>
-					<div class="info"><b>' . (HTMLpurify(($member->profile_display_name)?$member->profile_display_name:$member->username, 'unallowed')) . '</b></div>';
-					if($member->profile_bio) echo '<div class="info">'._('Bio').': '.(HTMLpurify($member->profile_bio, 'unallowed')).'</div>';
-					if($member->profile_twitter) echo '<div class="info">'._('X').': <a href="https://x.com/'.(HTMLpurify($member->profile_twitter, 'unallowed')).'" target="_blank">'.(HTMLpurify($member->profile_twitter, 'unallowed')).'</a></div>';
+			$member_name = htmlspecialchars(($member->profile_display_name) ? $member->profile_display_name : $member->username, ENT_QUOTES, 'UTF-8');
+			$member_bio = htmlspecialchars((string) $member->profile_bio, ENT_QUOTES, 'UTF-8');
+			$member_twitter = htmlspecialchars((string) $member->profile_twitter, ENT_QUOTES, 'UTF-8');
+			echo '<div class="element team-member">
+					<div class="image">'.get_gravatar($member->email, 75, NULL, NULL, TRUE, array('width' => '75', 'height' => '75', 'style' => 'width:75px;height:75px;')).'</div>
+					<div class="member-details">
+						<div class="title">' . $member_name . '</div>';
+					if($member->profile_bio) echo '<div class="member-meta">'._('Bio').': '.$member_bio.'</div>';
+					if($member->profile_twitter) echo '<div class="member-meta">'._('X').': <a href="https://x.com/'.$member_twitter.'" target="_blank">'.$member_twitter.'</a></div>';
+					echo '</div>';
 				echo '</div>';
 		}
 
@@ -62,11 +67,16 @@ if (!defined('BASEPATH'))
 		foreach ($members as $key => $member) {
 			if ($member->is_leader)
 				continue;
-			echo '<div class="element">
-					<div class="image">'.get_gravatar($member->email, 75, NULL, NULL, TRUE).'</div>
-					<div class="info"><b>' . (HTMLpurify(($member->profile_display_name)?$member->profile_display_name:$member->username, 'unallowed')) . '</b></div>';
-					if($member->profile_bio) echo '<div class="info">'._('Bio').': '.(HTMLpurify($member->profile_bio, 'unallowed')).'</div>';
-					if($member->profile_twitter) echo '<div class="info">'._('X').': <a href="https://x.com/'.(HTMLpurify($member->profile_twitter, 'unallowed')).'" target="_blank">'.(HTMLpurify($member->profile_twitter, 'unallowed')).'</a></div>';
+			$member_name = htmlspecialchars(($member->profile_display_name) ? $member->profile_display_name : $member->username, ENT_QUOTES, 'UTF-8');
+			$member_bio = htmlspecialchars((string) $member->profile_bio, ENT_QUOTES, 'UTF-8');
+			$member_twitter = htmlspecialchars((string) $member->profile_twitter, ENT_QUOTES, 'UTF-8');
+			echo '<div class="element team-member">
+					<div class="image">'.get_gravatar($member->email, 75, NULL, NULL, TRUE, array('width' => '75', 'height' => '75', 'style' => 'width:75px;height:75px;')).'</div>
+					<div class="member-details">
+						<div class="title">' . $member_name . '</div>';
+					if($member->profile_bio) echo '<div class="member-meta">'._('Bio').': '.$member_bio.'</div>';
+					if($member->profile_twitter) echo '<div class="member-meta">'._('X').': <a href="https://x.com/'.$member_twitter.'" target="_blank">'.$member_twitter.'</a></div>';
+					echo '</div>';
 				echo '</div>';
 		}
 	echo '</div>'

--- a/scripts/run-e2e-smoke.sh
+++ b/scripts/run-e2e-smoke.sh
@@ -654,7 +654,7 @@ else
 		if [ -n "$seeded_team_stub" ]; then
 			check_authed_page "/admin/members/home_team/" 1000 "<!DOCTYPE html"
 			check_authed_page "/admin/members/teams/${seeded_team_stub}" 1000 "<!DOCTYPE html"
-			check_page_fragment "/team/${seeded_team_stub}" 400 "teamworks/${seeded_team_stub}"
+			check_page "/team/${seeded_team_stub}" 1000 "teamworks/${seeded_team_stub}"
 		fi
 		team_stub="$(create_team_via_admin "Smoke Team ${smoke_suffix}")"
 		add_team_leader_via_admin "$team_stub" "$ADMIN_USER"


### PR DESCRIPTION
## Summary
- restore the public team member rows so populated team pages render correctly in both reader themes
- constrain gravatar sizing and use team-specific member row markup so avatars and member details align correctly
- tighten the e2e smoke check so seeded public team pages must return the full themed HTML page

## Verification
- ./scripts/run-tests.sh --with-e2e
- browser verification of the public team page layout for a populated team