### PR TITLE
fix: submit admin upload forms as multipart

### DIFF
--- a/application/views/admin/form.php
+++ b/application/views/admin/form.php
@@ -12,7 +12,8 @@
 <?php
 	if (isset($form_description)) echo '<span class="clearfix">' . $form_description . '</span>';
 	echo buttoner();
-	if (isset($multipart) && $multipart)
+	$has_upload = isset($table) && preg_match('/<input[^>]+type=["\']file["\']/i', $table);
+	if ((isset($multipart) && $multipart) || $has_upload)
 		echo form_open_multipart("", array('class' => 'form-stacked'));
 	else
 		echo form_open("", array('class' => 'form-stacked'));

--- a/tests/helpers/AdminFormViewTest.php
+++ b/tests/helpers/AdminFormViewTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/system/helpers/form_helper.php';
+
+if (!function_exists('get_instance'))
+{
+	function &get_instance()
+	{
+		return $GLOBALS['__admin_form_test_ci'];
+	}
+}
+
+if (!function_exists('buttoner'))
+{
+	function buttoner()
+	{
+		return '';
+	}
+}
+
+if (!function_exists('config_item'))
+{
+	function config_item($key)
+	{
+		if ($key === 'charset')
+		{
+			return 'UTF-8';
+		}
+
+		return null;
+	}
+}
+
+class AdminFormViewTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['__admin_form_test_ci'] = new AdminFormTestCi();
+	}
+
+	public function testGenericAdminFormWithFileInputUsesMultipartEncoding()
+	{
+		$table = '<input type="file" name="thumbnail" />';
+
+		ob_start();
+		include dirname(__DIR__, 2) . '/application/views/admin/form.php';
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('enctype="multipart/form-data"', $output);
+	}
+}
+
+class AdminFormTestCi
+{
+	public $config;
+	public $uri;
+	public $security;
+
+	public function __construct()
+	{
+		$this->config = new AdminFormTestConfig();
+		$this->uri = new AdminFormTestUri();
+		$this->security = new AdminFormTestSecurity();
+	}
+}
+
+class AdminFormTestConfig
+{
+	public function site_url($uri = '')
+	{
+		return 'http://localhost/' . ltrim((string) $uri, '/');
+	}
+
+	public function item($key)
+	{
+		return false;
+	}
+}
+
+class AdminFormTestUri
+{
+	public function uri_string()
+	{
+		return 'admin/series/add_new';
+	}
+}
+
+class AdminFormTestSecurity
+{
+	public function get_csrf_token_name()
+	{
+		return 'csrf';
+	}
+
+	public function get_csrf_hash()
+	{
+		return 'hash';
+	}
+}


### PR DESCRIPTION
## Summary\n- make generic admin forms use multipart encoding when their generated table contains a file input\n- add regression coverage for upload-capable admin forms\n\n## Verification\n- ./scripts/run-tests.sh --with-e2e\n- manual admin create-series flow with thumbnail upload; verified thumbnail filename persisted and original/thumb files were created\n\nFixes bd issue FoOlSlide-Improved-0yp.