### PR TITLE
fix: keep reader bar visible after page changes

### DIFF
--- a/content/themes/dazen-skin/views/read.php
+++ b/content/themes/dazen-skin/views/read.php
@@ -169,7 +169,9 @@ if (!defined('BASEPATH'))
 
   function resetReaderScroll()
   {
-    var readerTop = Math.max(jQuery('#page').offset().top - 6, 0);
+    var $readerBar = jQuery('.panel .topbar').first();
+    var scrollTarget = $readerBar.length ? $readerBar.offset().top : jQuery('#page').offset().top;
+    var readerTop = Math.max(scrollTarget - 6, 0);
     jQuery(window).scrollTop(readerTop);
     jQuery('html, body').scrollTop(readerTop);
     jQuery('#page').scrollLeft(0);

--- a/content/themes/default/views/read.php
+++ b/content/themes/default/views/read.php
@@ -100,7 +100,9 @@ if (!defined('BASEPATH'))
 
 	function resetReaderScroll()
 	{
-		var readerTop = Math.max(jQuery('#page').offset().top - 6, 0);
+		var $readerBar = jQuery('.panel .topbar').first();
+		var scrollTarget = $readerBar.length ? $readerBar.offset().top : jQuery('#page').offset().top;
+		var readerTop = Math.max(scrollTarget - 6, 0);
 		jQuery(window).scrollTop(readerTop);
 		jQuery('html, body').scrollTop(readerTop);
 		jQuery('#page').scrollLeft(0);

--- a/tests/helpers/ReaderScrollTargetTest.php
+++ b/tests/helpers/ReaderScrollTargetTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ReaderScrollTargetTest extends TestCase
+{
+	public function testPageChangesScrollToReaderBarInAvailableThemes()
+	{
+		foreach (array('dazen-skin', 'default') as $theme)
+		{
+			$source = file_get_contents(dirname(__DIR__, 2) . '/content/themes/' . $theme . '/views/read.php');
+
+			$this->assertStringContainsString("var \$readerBar = jQuery('.panel .topbar').first();", $source, $theme);
+			$this->assertStringContainsString("var scrollTarget = \$readerBar.length ? \$readerBar.offset().top : jQuery('#page').offset().top;", $source, $theme);
+			$this->assertStringContainsString('var readerTop = Math.max(scrollTarget - 6, 0);', $source, $theme);
+			$this->assertStringNotContainsString("var readerTop = Math.max(jQuery('#page').offset().top - 6, 0);", $source, $theme);
+		}
+	}
+}


### PR DESCRIPTION
Summary:
- Scroll reader page changes to the chapter/page bar instead of the image container.
- Apply the behavior to both dazen-skin and default themes.
- Add a regression test that checks both reader templates use the bar as the scroll target.

Verification:
- ./scripts/run-tests.sh
- ./scripts/run-tests.sh --with-e2e
- Manual browser verification at desktop size for dazen-skin and default: after changing pages, the top bar remains visible and the image remains visible.